### PR TITLE
Bugfix/unifire inputs

### DIFF
--- a/bin/prepare_unifire_input.py
+++ b/bin/prepare_unifire_input.py
@@ -53,7 +53,7 @@ def check_dir(directory_path):
 def reformat_line(line, taxid):
     line = line.lstrip(">").strip()
     id, description = line.split(maxsplit=1)
-    description = description.replace("'", "").replace("\"", "")
+    description = description.replace("\"", "").replace("'", "").replace("‘", "").replace("’", "")
     formatted_line = ">tr|{id}|{description} OX={taxid}\n".format(
         id=id, description=description, taxid=taxid
     )

--- a/bin/prepare_unifire_input.py
+++ b/bin/prepare_unifire_input.py
@@ -53,6 +53,7 @@ def check_dir(directory_path):
 def reformat_line(line, taxid):
     line = line.lstrip(">").strip()
     id, description = line.split(maxsplit=1)
+    description = description.replace("'", "").replace("\"", "")
     formatted_line = ">tr|{id}|{description} OX={taxid}\n".format(
         id=id, description=description, taxid=taxid
     )

--- a/bin/process_unifire_output.py
+++ b/bin/process_unifire_output.py
@@ -208,17 +208,17 @@ def load_unirule_arba(file):
             if not line.startswith("Evidence"):
                 parts = line.strip().split("\t")
                 if len(parts) == 6:
-                    pass  # skip feature lines with start and end coordinates
+                    pass  # don't do anything to feature lines with start and end coordinates
                 else:
-                    evidence, protein_id, annot_type, value = line.strip().split("\t")
-                if (
-                    not annot_type.startswith("comment")
-                    and not annot_type.startswith("protein.domain")
-                    and not annot_type.startswith("protein.component")
-                ):
-                    results_dict.setdefault(protein_id, dict()).setdefault(
-                        annot_type, list()
-                    ).append(value)
+                        evidence, protein_id, annot_type, value = line.strip().split("\t")
+                    if (
+                        not annot_type.startswith("comment")
+                        and not annot_type.startswith("protein.domain")
+                        and not annot_type.startswith("protein.component")
+                    ):
+                        results_dict.setdefault(protein_id, dict()).setdefault(
+                            annot_type, list()
+                        ).append(value)
     for record in results_dict:
         if "keyword" in results_dict[record]:
             if len(results_dict[record]["keyword"]) > 1:

--- a/bin/process_unifire_output.py
+++ b/bin/process_unifire_output.py
@@ -210,7 +210,7 @@ def load_unirule_arba(file):
                 if len(parts) == 6:
                     pass  # don't do anything to feature lines with start and end coordinates
                 else:
-                        evidence, protein_id, annot_type, value = line.strip().split("\t")
+                    evidence, protein_id, annot_type, value = line.strip().split("\t")
                     if (
                         not annot_type.startswith("comment")
                         and not annot_type.startswith("protein.domain")


### PR DESCRIPTION
- a bugfix for UniFIRE to correctly handle cases when the ARBA predictions file has 6 fields
- UniFIRE fails to parse files with quotes in descriptions; added removal of special characters to get around this