### PR TITLE
Unifre mount issue with docker.

### DIFF
--- a/modules/local/unifire.nf
+++ b/modules/local/unifire.nf
@@ -5,7 +5,13 @@ process UNIFIRE {
     label 'error_retry'
 
     container "dockerhub.ebi.ac.uk/uniprot-public/unifire:2023.4"
-    containerOptions "--bind unifire:/volume"
+    containerOptions {
+        if (workflow.containerEngine == 'singularity') {
+            return "--bind unifire:/volume"
+        } else {
+            return "-v unifire:/volume"
+        }
+    }
 
     input:
     tuple val(meta), path(faa, stageAs: "unifire/*")


### PR DESCRIPTION
The code was only using the singularity --bind flag, instead of checking the container engine used.

Now it supports docker -v for unifire, as it's done for IPS.
