### PR TITLE
Feature/split at gene calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ maximum length is 24 characters; the prefix may contain letters, digits, dashes,
 
 `taxid` is the NCBI TaxId (if the species-level TaxId is not known, a TaxId for a higher taxonomic level can be used). If the taxonomy is known, look up the TaxID [here](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi).
 
+#### External gene calls (optional columns)
+
+To use pre-computed gene calls for individual samples, add up to four optional columns:
+
+| Column | Description |
+|--------|-------------|
+| `gene_calls_gff` | GFF/GFF3 file with CDS features (anchor field) |
+| `gene_calls_faa` | Matching protein FASTA — required when `gene_calls_gff` is set |
+| `annotation_source` | Source format: `prokka`, `bakta`, or `ensembl` — required when `gene_calls_gff` is set |
+| `gene_calls_gbk` | Optional GenBank file; enables Pseudofinder, GECCO, antiSMASH, and SanntiS |
+
+Samples without external gene calls leave these columns empty. Standard (3-column) and extended-column rows can coexist in the same samplesheet.
+
 #### Finding TaxIds
 
 If NCBI taxonomies of input genomes are not known, a tool such as [CAT/BAT](https://github.com/MGXlab/CAT_pack) can be used.
@@ -281,6 +294,39 @@ nextflow run ebi-metagenomics/mettannotator \
    --outdir <OUTDIR> \
    --dbs <PATH/TO/WHERE/DBS/WILL/BE/SAVED>
 ```
+
+#### Gene-calling-only mode
+
+To run gene calling only and stop before functional annotation:
+
+```bash
+nextflow run ebi-metagenomics/mettannotator \
+   -profile <docker/singularity/...> \
+   --input assemblies_sheet.csv \
+   --outdir gene_calls_outdir \
+   --dbs <PATH/TO/DBS> \
+   --gene_calling_only
+```
+
+The outputs can then be reused in a separate full annotation run:
+
+```bash
+nextflow run ebi-metagenomics/mettannotator \
+   -profile <docker/singularity/...> \
+   --input assemblies_sheet.csv \
+   --outdir annotation_outdir \
+   --dbs <PATH/TO/DBS> \
+   --gene_calls gene_calls_outdir
+```
+
+`--gene_calls` discovers Prokka/Bakta outputs by sample prefix and skips gene calling.
+It cannot be combined with `--fast`, `--add_slow_tools`, or the samplesheet `gene_calls_gff` column.
+
+#### Per-sample external gene calls
+
+To use pre-computed gene calls from an external source (e.g. Ensembl Bacteria), add the optional samplesheet columns described in [External gene calls](#external-gene-calls-optional-columns)
+and set `annotation_source` accordingly. For `ensembl`, the GFF3 is normalised automatically
+and a GenBank file is generated if `gene_calls_gbk` is not provided.
 
 > [!WARNING]
 > Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -23,6 +23,30 @@
         "pattern": "^\\d+$",
         "errorMessage": "NCBI taxid should only contain digits.",
         "meta": ["taxid"]
+      },
+      "gene_calls_gff": {
+        "type": "string",
+        "pattern": "^(\\S+\\.gff3?)?$",
+        "errorMessage": "gene_calls_gff must be a path ending in .gff or .gff3, or left empty.",
+        "description": "Optional path to an external GFF/GFF3 file for this sample. When provided, Prokka/Bakta gene calling is skipped."
+      },
+      "gene_calls_faa": {
+        "type": "string",
+        "pattern": "^(\\S+\\.faa)?$",
+        "errorMessage": "gene_calls_faa must be a path ending in .faa, or left empty.",
+        "description": "Optional path to a protein FASTA (.faa) matching the external GFF. Required when gene_calls_gff is provided."
+      },
+      "gene_calls_gbk": {
+        "type": "string",
+        "pattern": "^(\\S+\\.gbk)?$",
+        "errorMessage": "gene_calls_gbk must be a path ending in .gbk, or left empty.",
+        "description": "Optional GenBank file for external gene call samples with prokka/bakta annotation source. Enables Pseudofinder, GECCO, antiSMASH, and SanntiS for those samples."
+      },
+      "annotation_source": {
+        "type": "string",
+        "enum": ["prokka", "bakta", "ensembl", ""],
+        "meta": ["annotation_source"],
+        "description": "Annotation source for external gene calls: prokka, bakta, or ensembl. Required when gene_calls_gff is provided."
       }
     },
     "required": ["prefix", "assembly", "taxid"]

--- a/bin/add_hypothetical_protein_descriptions.py
+++ b/bin/add_hypothetical_protein_descriptions.py
@@ -31,9 +31,10 @@ MINIMUM_IPR_MATCH = 0.10
 class GeneCaller(Enum):
     PROKKA = "Prokka"
     BAKTA = "Bakta"
+    ENSEMBL = "Ensembl"
 
 
-def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile):
+def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile, annotation_source="prokka"):
     eggnog_info = load_eggnog(eggnog_file)
     if ipr_file:
         levels = load_hierarchy(hierarchy_file)
@@ -43,7 +44,7 @@ def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile)
         ipr_info = dict()
         ipr_memberdb_only = dict()
 
-    gene_caller = GeneCaller.PROKKA
+    gene_caller = GeneCaller(annotation_source.capitalize())
     fasta_flag = False
     with open(infile) as file_in, open(outfile, "w") as file_out:
         for line in file_in:
@@ -1055,6 +1056,13 @@ def parse_args():
         required=True,
         help="Path to the output file where the result will be saved.",
     )
+    parser.add_argument(
+        "--annotation-source",
+        dest="annotation_source",
+        default="prokka",
+        choices=["prokka", "bakta", "ensembl"],
+        help="Gene calling source (default: prokka). Controls the product_source label.",
+    )
     return parser.parse_args()
 
 
@@ -1075,4 +1083,5 @@ if __name__ == "__main__":
         args.eggnog_output,
         args.infile,
         args.outfile,
+        args.annotation_source,
     )

--- a/bin/add_hypothetical_protein_descriptions.py
+++ b/bin/add_hypothetical_protein_descriptions.py
@@ -28,13 +28,21 @@ EGGNOG_NOTE_LENGTH_LIMIT = 70
 MINIMUM_IPR_MATCH = 0.10
 
 
-class GeneCaller(Enum):
-    PROKKA = "Prokka"
-    BAKTA = "Bakta"
-    ENSEMBL = "Ensembl"
+class GeneCaller(str, Enum):
+    PROKKA = "prokka"
+    BAKTA = "bakta"
+    ENSEMBL = "ensembl"
 
 
-def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile, annotation_source="prokka"):
+def main(
+    ipr_types_file,
+    ipr_file,
+    hierarchy_file,
+    eggnog_file,
+    infile,
+    outfile,
+    annotation_source: GeneCaller = GeneCaller.PROKKA,
+):
     eggnog_info = load_eggnog(eggnog_file)
     if ipr_file:
         levels = load_hierarchy(hierarchy_file)
@@ -44,7 +52,7 @@ def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile,
         ipr_info = dict()
         ipr_memberdb_only = dict()
 
-    gene_caller = GeneCaller(annotation_source.capitalize())
+    gene_caller = annotation_source
     fasta_flag = False
     with open(infile) as file_in, open(outfile, "w") as file_out:
         for line in file_in:
@@ -1059,8 +1067,9 @@ def parse_args():
     parser.add_argument(
         "--annotation-source",
         dest="annotation_source",
-        default="prokka",
-        choices=["prokka", "bakta", "ensembl"],
+        type=GeneCaller,
+        choices=GeneCaller,
+        default=GeneCaller.PROKKA,
         help="Gene calling source (default: prokka). Controls the product_source label.",
     )
     return parser.parse_args()

--- a/bin/add_taxid_to_faa.py
+++ b/bin/add_taxid_to_faa.py
@@ -42,6 +42,15 @@ def reformat_line(line, taxid):
     description = (
         description.replace('"', "").replace("'", "").replace("‘", "").replace("’", "")
     )
+    # InterProScan truncates the XML name attribute at 255 characters. If the
+    # description is long enough to push OX= past that limit, the taxid in the
+    # XML gets cut (e.g. OX=1523156 → OX=15), causing UNIFIRE to crash on an
+    # unrecognised taxid. Truncate here so OX= is always intact in the XML.
+    prefix = f"tr|{protein_id}|"
+    suffix = f" OX={taxid}"
+    max_desc = 255 - len(prefix) - len(suffix)
+    if len(description) > max_desc:
+        description = description[:max_desc]
     formatted_line = f">tr|{protein_id}|{description} OX={taxid}\n"
     return formatted_line
 

--- a/bin/normalize_ensembl_gff.py
+++ b/bin/normalize_ensembl_gff.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Normalise an Ensembl Bacteria GFF3 so that annotate_gff.py can process it.
+#
+# Ensembl GFF3 problems this script resolves:
+#   - CDS ID is "CDS:<protein_id>" — strip to bare protein_id
+#   - CDS features lack locus_tag and product — pulled from parent gene feature
+#   - ### separator lines accumulate as false header lines in annotate_gff.py
+#   - Ensembl-specific pragma headers (#!) are not informative for mettannotator
+#
+# Output: standard Prokka-style GFF3 with ID, locus_tag, product on every CDS.
+
+import argparse
+import urllib.parse
+import sys
+
+SKIP_FEATURES = {
+    "mRNA", "exon", "pseudogene", "pseudogenic_transcript",
+    "ncRNA_gene", "ncRNA", "pre_miRNA", "miRNA", "snoRNA", "snRNA",
+    "lnc_RNA", "antisense_RNA", "ribozyme",
+    "rRNA", "tRNA", "biological_region", "chromosome",
+    "region", "tmRNA",
+}
+
+
+def parse_col9(col9):
+    """Return an ordered list of (key, value) pairs from a GFF3 col9 string."""
+    pairs = []
+    for item in col9.split(";"):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" in item:
+            k, v = item.split("=", 1)
+            pairs.append((k, v))
+        else:
+            pairs.append((item, ""))
+    return pairs
+
+
+def col9_to_dict(col9):
+    return {k: v for k, v in parse_col9(col9)}
+
+
+def decode_description(text):
+    """URL-decode an Ensembl description field and sanitise for GFF3 col9."""
+    text = urllib.parse.unquote(text)
+    # Semicolons are col9 attribute separators — replace to avoid parse errors
+    text = text.replace(";", ",")
+    return text.strip()
+
+
+def normalise(in_gff, out_gff):
+    gene_info    = {}   # gene_id  -> {"name": str|None, "description": str|None}
+    mrna_to_gene = {}   # transcript_id -> gene_id
+
+    # --- Pass 1: collect gene and mRNA metadata ---
+    with open(in_gff) as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if line.startswith("#") or not line:
+                continue
+            cols = line.split("\t")
+            if len(cols) != 9:
+                continue
+            feature = cols[2]
+            attrs   = col9_to_dict(cols[8])
+
+            if feature == "gene":
+                # gene_id attribute is the stable identifier (e.g. ABAYE0001)
+                gid  = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
+                desc = decode_description(attrs.get("description", ""))
+                name = attrs.get("Name")
+                gene_info[gid] = {"name": name, "description": desc or None}
+
+            elif feature == "mRNA":
+                tid        = attrs.get("transcript_id") or attrs.get("ID", "").removeprefix("transcript:")
+                parent_raw = attrs.get("Parent", "")
+                gid        = parent_raw.removeprefix("gene:")
+                if tid and gid:
+                    mrna_to_gene[tid] = gid
+
+    # --- Pass 2: write normalised GFF3 ---
+    with open(in_gff) as fh, open(out_gff, "w") as out:
+        for line in fh:
+            line = line.rstrip("\n")
+
+            if not line:
+                continue
+
+            # GFF3 feature separator — discard
+            if line == "###":
+                continue
+
+            if line.startswith("#"):
+                # Keep standard GFF3 directives; drop Ensembl-specific pragmas (#!...)
+                if line.startswith("##gff-version") or line.startswith("##sequence-region"):
+                    out.write(line + "\n")
+                continue
+
+            cols = line.split("\t")
+            if len(cols) != 9:
+                continue
+
+            feature = cols[2]
+
+            if feature in SKIP_FEATURES:
+                continue
+
+            if feature == "gene":
+                attrs  = col9_to_dict(cols[8])
+                gid    = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
+                name   = attrs.get("Name")
+                # Match Prokka compliant format: gene ID gets _gene suffix so CDS can
+                # reference it via Parent=<gid>_gene
+                new_attrs = [("ID", f"{gid}_gene"), ("locus_tag", gid)]
+                if name:
+                    new_attrs.append(("Name", name))
+                cols[8] = ";".join(f"{k}={v}" for k, v in new_attrs)
+                out.write("\t".join(cols) + "\n")
+                continue
+
+            if feature not in {"CDS", "gene"}:
+                print(
+                    f"WARNING: Skipping unexpected feature type '{feature}' "
+                    f"at {cols[0]}:{cols[3]}-{cols[4]}",
+                    file=sys.stderr,
+                )
+                continue
+
+            attrs = col9_to_dict(cols[8])
+
+            # Stable protein accession — use protein_id if present, else strip CDS: prefix
+            protein_id = attrs.get("protein_id")
+            if not protein_id:
+                raw_id = attrs.get("ID", "")
+                protein_id = raw_id.removeprefix("CDS:")
+
+            if not protein_id:
+                print(
+                    f"WARNING: CDS at {cols[0]}:{cols[3]}-{cols[4]} has no protein_id — skipped",
+                    file=sys.stderr,
+                )
+                continue
+
+            # Resolve gene info via transcript → gene chain
+            tid       = attrs.get("Parent", "").removeprefix("transcript:")
+            gid       = mrna_to_gene.get(tid, "")
+            gene_meta = gene_info.get(gid, {})
+
+            product   = gene_meta.get("description") or "hypothetical protein"
+            gene_name = gene_meta.get("name")
+
+            # Build clean Prokka-compliant attributes.
+            # No Parent link: BCBio would nest CDS under gene as sub-features, causing
+            # gbk_generator to omit CDS from the GBK (it only iterates top-level features).
+            # Gene + CDS are linked implicitly by shared locus_tag, matching Prokka's GBK format.
+            new_attrs = [
+                ("ID",        protein_id),
+                ("locus_tag", gid if gid else protein_id),
+                ("product",   product),
+            ]
+            if gene_name:
+                new_attrs.append(("Name", gene_name))
+
+            cols[8] = ";".join(f"{k}={v}" for k, v in new_attrs)
+            out.write("\t".join(cols) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalise an Ensembl Bacteria GFF3 for mettannotator."
+    )
+    parser.add_argument("-i", "--input",  required=True, help="Input Ensembl GFF3")
+    parser.add_argument("-o", "--output", required=True, help="Output normalised GFF3")
+    args = parser.parse_args()
+    normalise(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -282,6 +282,23 @@ process {
         ]
     }
 
+    withName: NORMALIZE_ENSEMBL_GFF {
+        publishDir = [
+            path: { "${params.outdir}/${meta.prefix}/functional_annotation/ensembl_normalised" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : new File(filename).name }
+        ]
+    }
+
+    withName: GFF_TO_GBK {
+        ext.args = '--gene-caller-version "Ensembl"'
+        publishDir = [
+            path: { "${params.outdir}/${meta.prefix}/functional_annotation/ensembl_normalised" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : new File(filename).name }
+        ]
+    }
+
     withName: ANNOTATE_GFF {
         publishDir = [
             path: { "${params.outdir}/${meta.prefix}/functional_annotation/merged_gff" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -237,6 +237,16 @@ process {
         ]
     }
 
+    withName: PROKKA_COMPLIANT {
+        publishDir = [
+            enabled: params.gene_calling_only,
+            path: { "${params.outdir}/${meta.prefix}/functional_annotation/prokka_compliant" },
+            mode: params.publish_dir_mode,
+            pattern: "*_prokka/*.{gbk,gff}",
+            saveAs: { filename -> filename.split('/').last() }
+        ]
+    }
+
     withName: REVERT_CONTIG_RENAMING {
         publishDir = [
             path: { "${params.outdir}/${meta.prefix}/functional_annotation/prokka" },

--- a/lib/MettannotatorValidation.groovy
+++ b/lib/MettannotatorValidation.groovy
@@ -271,11 +271,33 @@ class MettannotatorValidation {
             )
         }
 
-        def sampleDirs = geneCallsDir.listFiles()?.findAll { it.isDirectory() } ?: []
+        def inputFile = new File(params.input as String)
+        def lines = inputFile.readLines()
+        def header = lines[0].split(',')*.trim()
+        def prefixIdx = header.indexOf('prefix')
+
+        if (prefixIdx < 0) {
+            Nextflow.error("Samplesheet '${inputFile}' has no 'prefix' column.")
+        }
+
         def errors = []
 
-        sampleDirs.each { sampleDir ->
-            def prefix = sampleDir.name
+        lines.drop(1).each { line ->
+            if (line.trim().isEmpty()) return
+
+            def prefix = line.split(',')*.trim()[prefixIdx]
+            def sampleDir = new File(geneCallsDir, prefix)
+
+            if (!sampleDir.isDirectory()) {
+                errors << (
+                    "Sample '${prefix}': output directory not found in gene calls directory.\n" +
+                    "  Expected: ${sampleDir.absolutePath}\n" +
+                    "  Ensure '--gene_calling_only' was run for this sample and that\n" +
+                    "  '--gene_calls' points to the correct output directory."
+                )
+                return
+            }
+
             def hasProkka = new File("${sampleDir}/functional_annotation/prokka").isDirectory()
             def hasBakta  = new File("${sampleDir}/functional_annotation/bakta").isDirectory()
 
@@ -297,6 +319,7 @@ class MettannotatorValidation {
 
         log.info "Gene calls input validation passed for all samples in '${params.gene_calls}'."
     }
+
 
     /**
      * Detect which annotator was used for a given sample by checking which

--- a/lib/MettannotatorValidation.groovy
+++ b/lib/MettannotatorValidation.groovy
@@ -370,4 +370,98 @@ class MettannotatorValidation {
 
         return current
     }
+
+    /**
+     * Validate samplesheet rows that use per-sample external gene calls.
+     * Called when the samplesheet contains a 'gene_calls_gff' column.
+     *   - annotation_source must be set (prokka/bakta/ensembl) when gene_calls_gff is set
+     *   - gene_calls_faa must be set when gene_calls_gff is set
+     *   - both files must exist on disk
+     */
+    public static void validateExternalGeneCalls(params, log) {
+        def inputFile = new File(params.input as String)
+        def lines     = inputFile.readLines()
+        def header    = lines[0].split(',')*.trim()
+
+        def gffIdx    = header.indexOf('gene_calls_gff')
+
+        // Column not present in samplesheet at all — nothing to validate.
+        if (gffIdx < 0) return
+
+        def prefixIdx = header.indexOf('prefix')
+        def faaIdx    = header.indexOf('gene_calls_faa')
+        def gbkIdx    = header.indexOf('gene_calls_gbk')
+        def sourceIdx = header.indexOf('annotation_source')
+
+        def valid_sources = ['prokka', 'bakta', 'ensembl'] as Set
+        def errors        = []
+
+        lines.drop(1).eachWithIndex { line, idx ->
+            if (line.trim().isEmpty()) return
+
+            def fields = line.split(',')*.trim()
+            def rowNum = idx + 2  // 1-based, accounting for header row
+
+            def prefix = prefixIdx >= 0 && prefixIdx < fields.size() ? fields[prefixIdx] : ''
+            def gff    = gffIdx    >= 0 && gffIdx    < fields.size() ? fields[gffIdx]    : ''
+            def faa    = faaIdx    >= 0 && faaIdx    < fields.size() ? fields[faaIdx]    : ''
+            def gbk    = gbkIdx    >= 0 && gbkIdx    < fields.size() ? fields[gbkIdx]    : ''
+            def source = sourceIdx >= 0 && sourceIdx < fields.size() ? fields[sourceIdx] : ''
+
+            if (!gff) {
+                // FAA, GBK, or annotation_source set without a GFF is likely a user mistake
+                if (faa || gbk || source) {
+                    errors << (
+                        "Row ${rowNum} (prefix='${prefix}'): 'gene_calls_faa', 'gene_calls_gbk', or " +
+                        "'annotation_source' is set but 'gene_calls_gff' is missing. " +
+                        "'gene_calls_gff' is required when providing external gene call files."
+                    )
+                }
+                return
+            }
+
+            if (!source || !valid_sources.contains(source)) {
+                errors << (
+                    "Row ${rowNum} (prefix='${prefix}'): 'gene_calls_gff' is set but " +
+                    "'annotation_source' is missing or invalid (got '${source}').\n" +
+                    "  Valid values: prokka, bakta, ensembl"
+                )
+            }
+
+            if (!faa) {
+                errors << (
+                    "Row ${rowNum} (prefix='${prefix}'): 'gene_calls_gff' is set but " +
+                    "'gene_calls_faa' is missing. Both must be provided together."
+                )
+            }
+
+            if (gff && !new File(gff).exists()) {
+                errors << (
+                    "Row ${rowNum} (prefix='${prefix}'): gene_calls_gff file not found:\n" +
+                    "  ${gff}"
+                )
+            }
+
+            if (faa && !new File(faa).exists()) {
+                errors << (
+                    "Row ${rowNum} (prefix='${prefix}'): gene_calls_faa file not found:\n" +
+                    "  ${faa}"
+                )
+            }
+
+            if (gbk && !new File(gbk).exists()) {
+                errors << (
+                    "Row ${rowNum} (prefix='${prefix}'): gene_calls_gbk file not found:\n" +
+                    "  ${gbk}"
+                )
+            }
+        }
+
+        if (errors) {
+            Nextflow.error(
+                "External gene-calls samplesheet validation failed:\n" +
+                errors.collect { "  - ${it}" }.join("\n")
+            )
+        }
+    }
 }

--- a/lib/WorkflowMettannotator.groovy
+++ b/lib/WorkflowMettannotator.groovy
@@ -16,6 +16,9 @@ class WorkflowMettannotator {
            MettannotatorValidation.checkVersionConsistency(params, log, workflow.manifest.name as String, workflow.manifest.version as String)
            MettannotatorValidation.validateFastRunInputs(params, log)
         }
+        if (params.gene_calls) {
+            MettannotatorValidation.validateGeneCallsInputs(params, log)
+        }
     }
 
     //

--- a/lib/WorkflowMettannotator.groovy
+++ b/lib/WorkflowMettannotator.groovy
@@ -12,6 +12,7 @@ class WorkflowMettannotator {
     //
     public static void initialise(params, log, workflow) {
         MettannotatorValidation.validateSamplesheetPrefixes(params, log)
+        MettannotatorValidation.validateExternalGeneCalls(params, log)
         if (params.add_slow_tools) {
            MettannotatorValidation.checkVersionConsistency(params, log, workflow.manifest.name as String, workflow.manifest.version as String)
            MettannotatorValidation.validateFastRunInputs(params, log)

--- a/main.nf
+++ b/main.nf
@@ -56,58 +56,45 @@ workflow EBIMETAGENOMICS_METTANNOTATOR {
         params.eggnog_db == null ||
         params.rfam_ncrna_models == null
     )) {
-        log.error "If the parameter '--dbs' is null, you must specify individual paths for each database."
-        System.exit(1)
+        error "If the parameter '--dbs' is null, you must specify individual paths for each database."
     }
 
     if (params.add_slow_tools && params.fast) {
-        log.error "'--add_slow_tools' and '--fast' cannot be used together. Use '--fast' for initial run, then '--add-slow-tools' to add slow annotations."
-        System.exit(1)
+        error "'--add_slow_tools' and '--fast' cannot be used together. Use '--fast' for initial run, then '--add-slow-tools' to add slow annotations."
     }
 
     if (params.skip_fast_staging && !params.add_slow_tools) {
-        log.error "'--skip_fast_staging' can only be used together with '--add_slow_tools'."
-        System.exit(1)
+        error "'--skip_fast_staging' can only be used together with '--add_slow_tools'."
     }
 
     if (params.allow_missing_files && !params.add_slow_tools) {
-        log.error "'--allow_missing_files' can only be used together with '--add_slow_tools'."
-        System.exit(1)
+        error "'--allow_missing_files' can only be used together with '--add_slow_tools'."
     }
 
     if (params.ignore_version_mismatch && !params.add_slow_tools) {
-        log.error "'--ignore_version_mismatch' can only be used together with '--add_slow_tools'."
-        System.exit(1)
+        error "'--ignore_version_mismatch' can only be used together with '--add_slow_tools'."
     }
 
     if (params.gene_calling_only && params.fast) {
-        log.error "'--gene_calling_only' and '--fast' cannot be used together."
-        System.exit(1)
+        error "'--gene_calling_only' and '--fast' cannot be used together."
     }
 
     if (params.gene_calling_only && params.add_slow_tools) {
-        log.error "'--gene_calling_only' and '--add_slow_tools' cannot be used together."
-        System.exit(1)
+        error "'--gene_calling_only' and '--add_slow_tools' cannot be used together."
     }
 
     if (params.gene_calling_only && params.gene_calls) {
-        log.error "'--gene_calling_only' and '--gene_calls' cannot be used together."
-        System.exit(1)
+        error "'--gene_calling_only' and '--gene_calls' cannot be used together."
     }
 
     if (params.gene_calls && params.add_slow_tools) {
-        log.error "'--gene_calls' and '--add_slow_tools' cannot be used together."
-        System.exit(1)
+        error "'--gene_calls' and '--add_slow_tools' cannot be used together."
     }
 
     if (params.gene_calls && params.input) {
         def ssHeader = new File(params.input as String).readLines()[0].split(',')*.trim()
         if (ssHeader.contains('gene_calls_gff')) {
-            log.error (
-                "'--gene_calls' cannot be used when the samplesheet contains a 'gene_calls_gff' " +
-                "column. Use one mechanism or the other, not both."
-            )
-            System.exit(1)
+           error "'--gene_calls' cannot be used when the samplesheet contains a 'gene_calls_gff' column. Use one mechanism or the other, not both."
         }
     }
 

--- a/main.nf
+++ b/main.nf
@@ -60,55 +60,46 @@ workflow EBIMETAGENOMICS_METTANNOTATOR {
         System.exit(1)
     }
 
-    // Validate add_slow_tools and fast are not used together
     if (params.add_slow_tools && params.fast) {
         log.error "'--add_slow_tools' and '--fast' cannot be used together. Use '--fast' for initial run, then '--add-slow-tools' to add slow annotations."
         System.exit(1)
     }
 
-    // Validate add_slow_tools and --skip-fast-staging are used together
     if (params.skip_fast_staging && !params.add_slow_tools) {
         log.error "'--skip_fast_staging' can only be used together with '--add_slow_tools'."
         System.exit(1)
     }
 
-    // Validate add_slow_tools and --allow-missing-files are used together
     if (params.allow_missing_files && !params.add_slow_tools) {
         log.error "'--allow_missing_files' can only be used together with '--add_slow_tools'."
         System.exit(1)
     }
 
-    // --ignore-version-mismatch only makes sense alongside --add_slow_tools
     if (params.ignore_version_mismatch && !params.add_slow_tools) {
         log.error "'--ignore_version_mismatch' can only be used together with '--add_slow_tools'."
         System.exit(1)
     }
 
-    // --gene_calling_only is incompatible with other run-mode flags
     if (params.gene_calling_only && params.fast) {
         log.error "'--gene_calling_only' and '--fast' cannot be used together."
         System.exit(1)
     }
+
     if (params.gene_calling_only && params.add_slow_tools) {
         log.error "'--gene_calling_only' and '--add_slow_tools' cannot be used together."
         System.exit(1)
     }
+
     if (params.gene_calling_only && params.gene_calls) {
         log.error "'--gene_calling_only' and '--gene_calls' cannot be used together."
         System.exit(1)
     }
 
-    // --gene_calls is incompatible with other run-mode flags
     if (params.gene_calls && params.add_slow_tools) {
         log.error "'--gene_calls' and '--add_slow_tools' cannot be used together."
         System.exit(1)
     }
-    if (params.gene_calls && params.fast) {
-        log.error "'--gene_calls' and '--fast' cannot be used together. Use '--gene_calling_only' first, then '--gene_calls' without '--fast' for the full annotation run."
-        System.exit(1)
-    }
 
-    // --gene_calls (directory) and samplesheet gene_calls_gff column are mutually exclusive.
     if (params.gene_calls && params.input) {
         def ssHeader = new File(params.input as String).readLines()[0].split(',')*.trim()
         if (ssHeader.contains('gene_calls_gff')) {

--- a/main.nf
+++ b/main.nf
@@ -108,6 +108,18 @@ workflow EBIMETAGENOMICS_METTANNOTATOR {
         System.exit(1)
     }
 
+    // --gene_calls (directory) and samplesheet gene_calls_gff column are mutually exclusive.
+    if (params.gene_calls && params.input) {
+        def ssHeader = new File(params.input as String).readLines()[0].split(',')*.trim()
+        if (ssHeader.contains('gene_calls_gff')) {
+            log.error (
+                "'--gene_calls' cannot be used when the samplesheet contains a 'gene_calls_gff' " +
+                "column. Use one mechanism or the other, not both."
+            )
+            System.exit(1)
+        }
+    }
+
     WorkflowMain.initialise(workflow, params, log)
     WorkflowMettannotator.initialise(params, log, workflow)
 

--- a/main.nf
+++ b/main.nf
@@ -84,6 +84,30 @@ workflow EBIMETAGENOMICS_METTANNOTATOR {
         System.exit(1)
     }
 
+    // --gene_calling_only is incompatible with other run-mode flags
+    if (params.gene_calling_only && params.fast) {
+        log.error "'--gene_calling_only' and '--fast' cannot be used together."
+        System.exit(1)
+    }
+    if (params.gene_calling_only && params.add_slow_tools) {
+        log.error "'--gene_calling_only' and '--add_slow_tools' cannot be used together."
+        System.exit(1)
+    }
+    if (params.gene_calling_only && params.gene_calls) {
+        log.error "'--gene_calling_only' and '--gene_calls' cannot be used together."
+        System.exit(1)
+    }
+
+    // --gene_calls is incompatible with other run-mode flags
+    if (params.gene_calls && params.add_slow_tools) {
+        log.error "'--gene_calls' and '--add_slow_tools' cannot be used together."
+        System.exit(1)
+    }
+    if (params.gene_calls && params.fast) {
+        log.error "'--gene_calls' and '--fast' cannot be used together. Use '--gene_calling_only' first, then '--gene_calls' without '--fast' for the full annotation run."
+        System.exit(1)
+    }
+
     WorkflowMain.initialise(workflow, params, log)
     WorkflowMettannotator.initialise(params, log, workflow)
 

--- a/modules/local/annotate_gff/main.nf
+++ b/modules/local/annotate_gff/main.nf
@@ -82,6 +82,7 @@ process ANNOTATE_GFF {
     if ( params.fast ) {
         hypothetical_tmp_gff = "${meta.prefix}_temp.gff"
     }
+    def annotation_source_flag = meta.annotation_source ? "--annotation-source ${meta.annotation_source}" : ""
     """
     annotate_gff.py \
     -g ${gff} \
@@ -104,7 +105,7 @@ process ANNOTATE_GFF {
     add_hypothetical_protein_descriptions.py \\
     --eggnog-output ${eggnog_annotations_tsv} \\
     -i ${hypothetical_tmp_gff} \\
-    -o ${meta.prefix}_annotations.gff ${hypothetical_ips_flags}
+    -o ${meta.prefix}_annotations.gff ${hypothetical_ips_flags} ${annotation_source_flag}
 
     prepare_gff_for_conversion.py \\
     -i ${meta.prefix}_annotations.gff \\

--- a/modules/local/gff_to_gbk.nf
+++ b/modules/local/gff_to_gbk.nf
@@ -1,0 +1,41 @@
+process GFF_TO_GBK {
+
+    tag "${meta.prefix}"
+
+    label 'process_single'
+
+    container 'quay.io/microbiome-informatics/mgnify-pipelines-toolkit:1.4.19'
+
+    input:
+    tuple val(meta), path(gff), path(faa), path(contigs)
+
+    output:
+    tuple val(meta), path("${meta.prefix}.gbk"), emit: gbk
+    path "versions.yml",                          emit: versions
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    gbk_generator \\
+        --contigs ${contigs} \\
+        --gff ${gff} \\
+        --faa ${faa} \\
+        --output_gbk ${meta.prefix}.gbk \\
+        ${args}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mgnify-pipelines-toolkit: \$(get_mpt_version)
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${meta.prefix}.gbk
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mgnify-pipelines-toolkit: \$(get_mpt_version)
+    END_VERSIONS
+    """
+}

--- a/modules/local/lookup_kingdom.nf
+++ b/modules/local/lookup_kingdom.nf
@@ -28,5 +28,9 @@ process LOOKUP_KINGDOM {
     stub:
     """
     detected_kingdom="Bacteria"
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+    END_VERSIONS
     """
 }

--- a/modules/local/normalize_ensembl_gff/main.nf
+++ b/modules/local/normalize_ensembl_gff/main.nf
@@ -1,0 +1,38 @@
+process NORMALIZE_ENSEMBL_GFF {
+
+    tag "${meta.prefix}"
+
+    label 'process_nano'
+
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] ?
+        'https://depot.galaxyproject.org/singularity/python:3.9' :
+        'biocontainers/python:3.9' }"
+
+    input:
+    tuple val(meta), path(ensembl_gff)
+
+    output:
+    tuple val(meta), path("${meta.prefix}_normalised.gff"), emit: normalised_gff
+    path "versions.yml",                                    emit: versions
+
+    script:
+    """
+    normalize_ensembl_gff.py \\
+        -i ${ensembl_gff} \\
+        -o ${meta.prefix}_normalised.gff
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${meta.prefix}_normalised.gff
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,12 @@ params {
     // Skip the version consistency check when running --add_slow_tools against a different pipeline version
     ignore_version_mismatch        = false
 
+    // Run only the gene calling step (Prokka/Bakta) and stop
+    gene_calling_only              = false
+
+    // Path to existing gene calling output directory to skip Prokka/Bakta
+    gene_calls                     = null
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -66,6 +66,19 @@
           "help_text": "By default, when --add-slow-tools is used, the pipeline checks that the fast-run results were produced by the same pipeline version. Use this flag to suppress the version mismatch error and proceed anyway — a warning will still be printed. Can only be used together with --add-slow-tools.",
           "fa_icon": "fas fa-code-branch"
         },
+        "gene_calling_only": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run only the gene calling step (Prokka/Bakta) and stop. Outputs can be used with --gene-calls in a subsequent run.",
+          "help_text": "When set, the pipeline runs LOOKUP_KINGDOM and Prokka/Bakta, writes all gene calling outputs to --outdir, then stops. Cannot be used together with --fast, --add-slow-tools, or --gene-calls.",
+          "fa_icon": "fas fa-dna"
+        },
+        "gene_calls": {
+          "type": "string",
+          "description": "Path to an existing gene calling output directory. Skips Prokka/Bakta and starts the pipeline from annotation.",
+          "help_text": "The directory must contain Prokka or Bakta outputs in the standard mettannotator layout (functional_annotation/prokka/ or functional_annotation/bakta/). Cannot be used together with --add-slow-tools or --gene-calling-only.",
+          "fa_icon": "fas fa-folder-open"
+        },
         "email": {
           "type": "string",
           "description": "Email address for completion summary.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -76,7 +76,7 @@
         "gene_calls": {
           "type": "string",
           "description": "Path to an existing gene calling output directory. Skips Prokka/Bakta and starts the pipeline from annotation.",
-          "help_text": "The directory must contain Prokka or Bakta outputs in the standard mettannotator layout (functional_annotation/prokka/ or functional_annotation/bakta/). Cannot be used together with --add-slow-tools or --gene-calling-only.",
+          "help_text": "The directory must follow the standard mettannotator layout. When --bakta is set, Bakta outputs are expected at functional_annotation/bakta/. Otherwise, Prokka outputs are expected at functional_annotation/prokka/ (standard annotation) and functional_annotation/prokka_compliant/ (used by Pseudofinder). The samplesheet must still specify the assembly FASTA and taxid. Cannot be used together with --add-slow-tools or --gene-calling-only.",
           "fa_icon": "fas fa-folder-open"
         },
         "email": {

--- a/tests/scripts/test_add_hypothetical_protein_descriptions.py
+++ b/tests/scripts/test_add_hypothetical_protein_descriptions.py
@@ -196,7 +196,7 @@ def test_keep_or_move_to_note_sentence():
     )
     assert result == (
         "hypothetical protein",
-        "Prokka",
+        "prokka",
         {"ID": "123", "locus_tag": "locus_tag", "Note": "eggNOG:This is a protein"},
     )
 

--- a/tests/scripts/test_normalize_gff.py
+++ b/tests/scripts/test_normalize_gff.py
@@ -1,0 +1,273 @@
+import pytest
+
+from bin.normalize_ensembl_gff import (
+    col9_to_dict,
+    decode_description,
+    normalise,
+    parse_col9,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GENE = (
+    "contig_1\tEnsembl\tgene\t100\t300\t.\t+\t.\t"
+    "ID=gene:ABAYE0001;gene_id=ABAYE0001;Name=recA;description=DNA%20recombinase%20A\n"
+)
+MRNA = (
+    "contig_1\tEnsembl\tmRNA\t100\t300\t.\t+\t.\t"
+    "ID=transcript:T001;Parent=gene:ABAYE0001;transcript_id=T001\n"
+)
+CDS_WITH_PROTEIN_ID = (
+    "contig_1\tEnsembl\tCDS\t100\t300\t.\t+\t0\t"
+    "ID=CDS:PROT001;Parent=transcript:T001;protein_id=PROT001\n"
+)
+CDS_WITHOUT_PROTEIN_ID = (
+    "contig_1\tEnsembl\tCDS\t100\t300\t.\t+\t0\t"
+    "ID=CDS:PROT001;Parent=transcript:T001\n"
+)
+
+
+def run(tmp_path, *lines):
+    in_f = tmp_path / "in.gff"
+    out_f = tmp_path / "out.gff"
+    in_f.write_text("##gff-version 3\n" + "".join(lines))
+    normalise(str(in_f), str(out_f))
+    return out_f.read_text().splitlines()
+
+
+def cds(lines):
+    return [line for line in lines if "\tCDS\t" in line]
+
+
+def genes(lines):
+    return [line for line in lines if "\tgene\t" in line]
+
+
+# ---------------------------------------------------------------------------
+# parse_col9
+# ---------------------------------------------------------------------------
+
+
+def test_parse_col9_basic():
+    assert parse_col9("ID=gene:G1;Name=recA;gene_id=G1") == [
+        ("ID", "gene:G1"),
+        ("Name", "recA"),
+        ("gene_id", "G1"),
+    ]
+
+
+def test_parse_col9_empty_segments_ignored():
+    assert parse_col9("ID=foo;;Name=bar") == [("ID", "foo"), ("Name", "bar")]
+
+
+def test_parse_col9_attribute_without_value():
+    assert parse_col9("ID=foo;flag") == [("ID", "foo"), ("flag", "")]
+
+
+def test_parse_col9_value_containing_equals():
+    # Only the first = splits key from value
+    assert parse_col9("ID=foo;description=a=b") == [
+        ("ID", "foo"),
+        ("description", "a=b"),
+    ]
+
+
+def test_parse_col9_single_attribute():
+    assert parse_col9("ID=only") == [("ID", "only")]
+
+
+# ---------------------------------------------------------------------------
+# col9_to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_col9_to_dict_basic():
+    result = col9_to_dict("ID=G1;Name=recA")
+    assert result == {"ID": "G1", "Name": "recA"}
+
+
+def test_col9_to_dict_last_wins_on_duplicate_keys():
+    # dict comprehension keeps last value for duplicate keys
+    result = col9_to_dict("ID=first;ID=second")
+    assert result["ID"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# decode_description
+# ---------------------------------------------------------------------------
+
+
+def test_decode_description_url_encoded_spaces():
+    assert decode_description("DNA%20repair%20protein") == "DNA repair protein"
+
+
+def test_decode_description_semicolons_replaced_with_comma():
+    assert decode_description("func1;func2") == "func1,func2"
+
+
+def test_decode_description_percent_encoded_semicolon():
+    assert decode_description("func1%3Bfunc2") == "func1,func2"
+
+
+def test_decode_description_strips_whitespace():
+    assert decode_description("  protein  ") == "protein"
+
+
+def test_decode_description_empty_string():
+    assert decode_description("") == ""
+
+
+def test_decode_description_no_encoding():
+    assert decode_description("kinase") == "kinase"
+
+
+# ---------------------------------------------------------------------------
+# normalise — header handling
+# ---------------------------------------------------------------------------
+
+
+def test_gff_version_directive_kept(tmp_path):
+    lines = run(tmp_path)
+    assert "##gff-version 3" in lines
+
+
+def test_sequence_region_directive_kept(tmp_path):
+    in_f = tmp_path / "in.gff"
+    out_f = tmp_path / "out.gff"
+    in_f.write_text("##gff-version 3\n##sequence-region contig_1 1 5000\n")
+    normalise(str(in_f), str(out_f))
+    assert "##sequence-region contig_1 1 5000" in out_f.read_text().splitlines()
+
+
+def test_ensembl_pragma_dropped(tmp_path):
+    lines = run(tmp_path, "#!genome-build GCA_000007405.1\n")
+    assert not any(line.startswith("#!") for line in lines)
+
+
+def test_separator_lines_dropped(tmp_path):
+    lines = run(tmp_path, "###\n###\n")
+    assert "###" not in lines
+
+
+# ---------------------------------------------------------------------------
+# normalise — feature filtering
+# ---------------------------------------------------------------------------
+
+
+def test_mrna_feature_dropped(tmp_path):
+    lines = run(tmp_path, MRNA)
+    assert not any("\tmRNA\t" in line for line in lines)
+
+
+@pytest.mark.parametrize(
+    "feature",
+    ["exon", "pseudogene", "ncRNA_gene", "rRNA", "tRNA", "biological_region"],
+)
+def test_skip_features_dropped(tmp_path, feature):
+    feat_line = f"contig_1\tEnsembl\t{feature}\t1\t100\t.\t+\t.\tID=x\n"
+    lines = run(tmp_path, feat_line)
+    assert not any(f"\t{feature}\t" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# normalise — gene features
+# ---------------------------------------------------------------------------
+
+
+def test_gene_id_gets_gene_suffix(tmp_path):
+    gl = genes(run(tmp_path, GENE))
+    assert len(gl) == 1
+    assert "ID=ABAYE0001_gene" in gl[0]
+
+
+def test_gene_locus_tag_set(tmp_path):
+    gl = genes(run(tmp_path, GENE))
+    assert "locus_tag=ABAYE0001" in gl[0]
+
+
+def test_gene_name_kept_when_present(tmp_path):
+    gl = genes(run(tmp_path, GENE))
+    assert "Name=recA" in gl[0]
+
+
+def test_gene_name_omitted_when_absent(tmp_path):
+    gene_no_name = (
+        "contig_1\tEnsembl\tgene\t1\t100\t.\t+\t.\t"
+        "ID=gene:G2;gene_id=G2;description=some%20protein\n"
+    )
+    gl = genes(run(tmp_path, gene_no_name))
+    assert "Name=" not in gl[0]
+
+
+# ---------------------------------------------------------------------------
+# normalise — CDS features
+# ---------------------------------------------------------------------------
+
+
+def test_cds_protein_id_used_as_id(tmp_path):
+    cl = cds(run(tmp_path, GENE, MRNA, CDS_WITH_PROTEIN_ID))
+    assert len(cl) == 1
+    assert "ID=PROT001" in cl[0]
+    assert "ID=CDS:" not in cl[0]
+
+
+def test_cds_prefix_stripped_when_no_protein_id(tmp_path):
+    cl = cds(run(tmp_path, GENE, MRNA, CDS_WITHOUT_PROTEIN_ID))
+    assert "ID=PROT001" in cl[0]
+    assert "ID=CDS:" not in cl[0]
+
+
+def test_cds_product_from_parent_gene(tmp_path):
+    cl = cds(run(tmp_path, GENE, MRNA, CDS_WITH_PROTEIN_ID))
+    assert "product=DNA recombinase A" in cl[0]
+
+
+def test_cds_product_hypothetical_when_no_gene_info(tmp_path):
+    cl = cds(run(tmp_path, CDS_WITH_PROTEIN_ID))
+    assert "product=hypothetical protein" in cl[0]
+
+
+def test_cds_has_no_parent_attribute(tmp_path):
+    cl = cds(run(tmp_path, GENE, MRNA, CDS_WITH_PROTEIN_ID))
+    assert "Parent=" not in cl[0]
+
+
+def test_cds_locus_tag_from_parent_gene(tmp_path):
+    cl = cds(run(tmp_path, GENE, MRNA, CDS_WITH_PROTEIN_ID))
+    assert "locus_tag=ABAYE0001" in cl[0]
+
+
+def test_cds_description_url_decoded(tmp_path):
+    gene = (
+        "contig_1\tEnsembl\tgene\t1\t100\t.\t+\t.\t"
+        "ID=gene:G3;gene_id=G3;description=DNA%20repair%20protein\n"
+    )
+    mrna = (
+        "contig_1\tEnsembl\tmRNA\t1\t100\t.\t+\t.\t"
+        "ID=transcript:T003;Parent=gene:G3;transcript_id=T003\n"
+    )
+    cds_line = (
+        "contig_1\tEnsembl\tCDS\t1\t100\t.\t+\t0\t"
+        "ID=CDS:P003;Parent=transcript:T003;protein_id=P003\n"
+    )
+    cl = cds(run(tmp_path, gene, mrna, cds_line))
+    assert "product=DNA repair protein" in cl[0]
+
+
+def test_cds_description_semicolons_replaced(tmp_path):
+    gene = (
+        "contig_1\tEnsembl\tgene\t1\t100\t.\t+\t.\t"
+        "ID=gene:G4;gene_id=G4;description=func1%3Bfunc2\n"
+    )
+    mrna = (
+        "contig_1\tEnsembl\tmRNA\t1\t100\t.\t+\t.\t"
+        "ID=transcript:T004;Parent=gene:G4;transcript_id=T004\n"
+    )
+    cds_line = (
+        "contig_1\tEnsembl\tCDS\t1\t100\t.\t+\t0\t"
+        "ID=CDS:P004;Parent=transcript:T004;protein_id=P004\n"
+    )
+    cl = cds(run(tmp_path, gene, mrna, cds_line))
+    assert "product=func1,func2" in cl[0]

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -38,6 +38,9 @@ include { CIRCOS_PLOT                                } from '../modules/local/ci
 include { PSEUDOFINDER                               } from '../modules/local/pseudofinder'
 include { PSEUDOFINDER_POSTPROCESSING                } from '../modules/local/pseudofinder'
 include { STAGE_FAST_OUTPUTS                         } from '../modules/local/stage_fast_outputs'
+include { NORMALIZE_ENSEMBL_GFF                      } from '../modules/local/normalize_ensembl_gff'
+include { GFF_TO_GBK                                 } from '../modules/local/gff_to_gbk'
+
 
 include { DOWNLOAD_DATABASES                         } from '../subworkflows/download_databases'
 
@@ -346,13 +349,64 @@ workflow METTANNOTATOR {
 
     } else {
 
-        assemblies = Channel.fromSamplesheet("input")
+        assemblies_raw = Channel.fromSamplesheet("input")
+        // [meta, assembly] for all samples — feeds LOOKUP_KINGDOM and all assembly-level tools
+        assemblies = assemblies_raw.map { row -> [row[0], row[1]] }
         annotations_fna = channel.empty()
         annotations_gbk = channel.empty()
         annotations_faa = channel.empty()
         annotations_gff = channel.empty()
         compliant_gbk = channel.empty()
         compliant_gff = channel.empty()
+
+        // Per-sample external gene calls: rows where annotation_source is prokka/bakta/ensembl.
+        // When the gene_calls_gff column is absent (standard samplesheet), this channel is empty.
+        // Tuple: [meta, assembly, gene_calls_gff, gene_calls_faa, gene_calls_gbk]
+        ext_gene_call_rows = assemblies_raw
+            .filter { it[0].annotation_source in ['prokka', 'bakta', 'ensembl'] }
+            .map { [it[0], it[1], it[2], it[3], it[4]] }
+
+        ext_gene_call_rows.branch {
+            ensembl: it[0].annotation_source == 'ensembl'
+            direct:  true   // prokka or bakta — GFF used as-is
+        }.set { ext_gc_branches }
+
+        NORMALIZE_ENSEMBL_GFF(
+            ext_gc_branches.ensembl.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
+        )
+        ch_versions = ch_versions.mix(NORMALIZE_ENSEMBL_GFF.out.versions)
+
+        // Ensembl samples with a user-supplied GBK skip GFF_TO_GBK.
+        ext_gc_branches.ensembl.branch {
+            has_gbk:   it[4]
+            needs_gbk: true
+        }.set { ensembl_gbk_branches }
+
+        GFF_TO_GBK(
+            NORMALIZE_ENSEMBL_GFF.out.normalised_gff
+                .join( ensembl_gbk_branches.needs_gbk.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
+                .join( ensembl_gbk_branches.needs_gbk.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
+        )
+        ch_versions = ch_versions.mix(GFF_TO_GBK.out.versions)
+
+        ext_annotations_gff = NORMALIZE_ENSEMBL_GFF.out.normalised_gff
+            .mix( ext_gc_branches.direct.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] } )
+        ext_annotations_faa = ext_gc_branches.ensembl.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] }
+            .mix( ext_gc_branches.direct.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
+        ext_annotations_fna = ext_gc_branches.ensembl.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] }
+            .mix( ext_gc_branches.direct.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
+
+        // Any external sample (ensembl or direct) that provides a GBK uses it directly,
+        // bypassing GFF_TO_GBK. compliant_gff for direct samples uses their GFF as-is
+        // (no contig renaming). Ensembl compliant_gff comes from NORMALIZE_ENSEMBL_GFF.
+        ext_gbk = ensembl_gbk_branches.has_gbk
+            .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] }
+            .mix( ext_gc_branches.direct
+                .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
+                .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] } )
+        ext_direct_compliant_gff = ext_gc_branches.direct
+            .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
+            .map    { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
 
         LOOKUP_KINGDOM( assemblies )
         ch_versions = ch_versions.mix(LOOKUP_KINGDOM.out.versions.first())
@@ -404,9 +458,14 @@ workflow METTANNOTATOR {
 
         } else {
 
+            // Exclude samples that supply per-sample external gene calls from Prokka/Bakta
+            assemblies_for_gene_calling = assemblies_with_kingdom.filter { meta, _assembly, _kingdom ->
+                !(meta.annotation_source in ['prokka', 'bakta', 'ensembl'])
+            }
+
             if ( params.bakta ) {
 
-                assemblies_with_kingdom.branch {
+                assemblies_for_gene_calling.branch {
                     bacteria: it[2] == "Bacteria"
                     archaea: it[2] == "Archaea"
                 }.set { assemblies_to_annotate }
@@ -418,7 +477,7 @@ workflow METTANNOTATOR {
 
             } else {
 
-                prokka_input = assemblies_with_kingdom
+                prokka_input = assemblies_for_gene_calling
 
             }
 
@@ -473,6 +532,16 @@ workflow METTANNOTATOR {
                 compliant_gff = PROKKA_COMPLIANT.out.gff
             }
         }
+
+        // Mix per-sample external gene calls (samplesheet gene_calls_gff column) into the main
+        // annotation channels. Empty no-op when no external gene calls are provided.
+        annotations_gff = annotations_gff.mix(ext_annotations_gff)
+        annotations_faa = annotations_faa.mix(ext_annotations_faa)
+        annotations_fna = annotations_fna.mix(ext_annotations_fna)
+        annotations_gbk = annotations_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
+        compliant_gbk   = compliant_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
+        compliant_gff   = compliant_gff.mix(NORMALIZE_ENSEMBL_GFF.out.normalised_gff).mix(ext_direct_compliant_gff)
+
 
         if ( !params.gene_calling_only ) {
 
@@ -659,12 +728,11 @@ workflow METTANNOTATOR {
                     UNIFIRE.out.pirsr, remainder: true
                 )
             } else {
-                annotate_gff_input = annotate_gff_input.map { it -> {
+                annotate_gff_input = annotate_gff_input.map { it ->
                         // IPS, SanntiS, UniFire{arba,unirule,pirsr}
                         // meta, <files> //
                         it + [[], [], [], [], []]
                     }
-                }
             }
 
             ANNOTATE_GFF(

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -359,324 +359,356 @@ workflow METTANNOTATOR {
 
         assemblies_with_kingdom = assemblies.join( LOOKUP_KINGDOM.out.detected_kingdom )
 
-        if ( params.bakta ) {
+        if ( params.gene_calls ) {
 
-            assemblies_with_kingdom.branch {
-                bacteria: it[2] == "Bacteria"
-                archaea: it[2] == "Archaea"
-            }.set { assemblies_to_annotate }
+            def gene_calls_dir = file(params.gene_calls)
 
-            BAKTA_BAKTA( assemblies_to_annotate.bacteria, bakta_db )
-            ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions.first())
-
-            prokka_input = assemblies_to_annotate.archaea
-
-        } else {
-
-            prokka_input = assemblies_with_kingdom
-
-        }
-
-        // Prokka crashes with long contig names, so we temporary rename contigs before running it
-        SHORTEN_CONTIG_NAMES(
-            prokka_input.map { meta, fasta, _kingdom -> [ meta, fasta ] },
-            []
-        )
-        ch_versions = ch_versions.mix(SHORTEN_CONTIG_NAMES.out.versions.first())
-
-        renamed_prokka_input = SHORTEN_CONTIG_NAMES.out.modified_fasta
-            .join( prokka_input )
-            .map { meta, renamed_fasta, _original_fasta, kingdom ->
-                [ meta, renamed_fasta, kingdom ]
+            def load_files = { pattern, strip_suffix ->
+                channel
+                    .fromPath(pattern, checkIfExists: false)
+                    .map { f ->
+                        def name = f.name.replaceAll(strip_suffix + '$', '')
+                        tuple(name, f)
+                    }
             }
-        PROKKA_STANDARD( renamed_prokka_input, Channel.value("standard") )
-        PROKKA_COMPLIANT( renamed_prokka_input, Channel.value("compliant") )
 
-        ch_versions = ch_versions.mix(PROKKA_STANDARD.out.versions.first())
+            // Preserve the original samplesheet meta (needed for downstream joins, e.g. LOOKUP_KINGDOM)
+            assemblies_by_prefix = assemblies.map { meta, assembly -> [meta.prefix, meta] }
 
-        // Revert contig renaming in both GBK and GFF files, so they match the original FASTA
-        PROKKA_STANDARD.out.gbk
-            .mix(PROKKA_STANDARD.out.gff)
-            .mix(PROKKA_STANDARD.out.fna)
-            .groupTuple()
-            .join(SHORTEN_CONTIG_NAMES.out.fasta_ids_mapping)
-            .multiMap { meta, files_list, names_mapping ->
-                files: [ meta, files_list ]
-                mapping: names_mapping
-        }.set { revert_contig_renaming_input }
-        REVERT_CONTIG_RENAMING(
-            revert_contig_renaming_input.files,
-            revert_contig_renaming_input.mapping
-        )
+            // Load annotation files from the appropriate tool's output directory.
+            // When --bakta is set, load from functional_annotation/bakta/ (bakta compliant = standard bakta outputs).
+            // Otherwise load from functional_annotation/prokka/ and functional_annotation/prokka_compliant/.
+            // Prokka: .faa / .gbk / .gff / .fna   Bakta: .faa / .gbff / .gff3 / .fna
+            if ( params.bakta ) {
+                gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.faa",   '\\.faa')
+                gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
+                gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
+                gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.fna",   '\\.fna')
+                gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
+                gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
+            } else {
+                gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.faa",            '\\.faa')
+                gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gbk",            '\\.gbk')
+                gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gff",            '\\.gff')
+                gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.fna",            '\\.fna')
+                gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gbk", '\\.gbk')
+                gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gff", '\\.gff')
+            }
 
-        if ( params.bakta ) {
-
-            annotations_gbk = annotations_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( REVERT_CONTIG_RENAMING.out.modified_gbk )
-            annotations_gff = annotations_gff.mix( BAKTA_BAKTA.out.gff ).mix( REVERT_CONTIG_RENAMING.out.modified_gff )
-            annotations_fna = annotations_fna.mix( BAKTA_BAKTA.out.fna ).mix( REVERT_CONTIG_RENAMING.out.modified_fasta )
-            annotations_faa = annotations_faa.mix( BAKTA_BAKTA.out.faa ).mix( PROKKA_STANDARD.out.faa )
-            compliant_gbk = compliant_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( PROKKA_COMPLIANT.out.gbk )
-            compliant_gff = compliant_gff.mix( BAKTA_BAKTA.out.gff ).mix( PROKKA_COMPLIANT.out.gff )
+            annotations_faa  = assemblies_by_prefix.join(gc_faa).map           { prefix, meta, f -> tuple(meta, f) }
+            annotations_gbk  = assemblies_by_prefix.join(gc_gbk).map           { prefix, meta, f -> tuple(meta, f) }
+            annotations_gff  = assemblies_by_prefix.join(gc_gff).map           { prefix, meta, f -> tuple(meta, f) }
+            annotations_fna  = assemblies_by_prefix.join(gc_fna).map           { prefix, meta, f -> tuple(meta, f) }
+            compliant_gbk    = assemblies_by_prefix.join(gc_compliant_gbk).map { prefix, meta, f -> tuple(meta, f) }
+            compliant_gff    = assemblies_by_prefix.join(gc_compliant_gff).map { prefix, meta, f -> tuple(meta, f) }
 
         } else {
 
-            annotations_gbk = REVERT_CONTIG_RENAMING.out.modified_gbk
-            annotations_gff = REVERT_CONTIG_RENAMING.out.modified_gff
-            annotations_fna = REVERT_CONTIG_RENAMING.out.modified_fasta
-            annotations_faa = PROKKA_STANDARD.out.faa
+            if ( params.bakta ) {
 
-            compliant_gbk = PROKKA_COMPLIANT.out.gbk
-            compliant_gff = PROKKA_COMPLIANT.out.gff
-        }
+                assemblies_with_kingdom.branch {
+                    bacteria: it[2] == "Bacteria"
+                    archaea: it[2] == "Archaea"
+                }.set { assemblies_to_annotate }
 
-        assemblies_for_quast = assemblies.join(
-            annotations_gff
-        ).map { it -> tuple(it[0], it[1], it[2]) }
+                BAKTA_BAKTA( assemblies_to_annotate.bacteria, bakta_db )
+                ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions.first())
 
-        QUAST(
-            assemblies_for_quast.map { tuple(it[0], it[1]) }, // the assembly
-            assemblies_for_quast.map { tuple(it[0], it[2]) }, // the GFF
-        )
+                prokka_input = assemblies_to_annotate.archaea
 
-        ch_versions = ch_versions.mix(QUAST.out.versions.first())
+            } else {
 
-        PSEUDOFINDER(
-            compliant_gbk,
-            pseudofinder_db
-        )
+                prokka_input = assemblies_with_kingdom
 
-        ch_versions = ch_versions.mix(PSEUDOFINDER.out.versions.first())
+            }
 
-        PSEUDOFINDER_POSTPROCESSING(
-            annotations_gff.join(
-                compliant_gff
-            ).join(
-                PSEUDOFINDER.out.pseudofinder_gff
+            // Prokka crashes with long contig names, so we temporary rename contigs before running it
+            SHORTEN_CONTIG_NAMES(
+                prokka_input.map { meta, fasta, _kingdom -> [ meta, fasta ] },
+                []
             )
-        )
+            ch_versions = ch_versions.mix(SHORTEN_CONTIG_NAMES.out.versions.first())
 
-        ch_versions = ch_versions.mix(PSEUDOFINDER_POSTPROCESSING.out.versions.first())
+            renamed_prokka_input = SHORTEN_CONTIG_NAMES.out.modified_fasta
+                .join( prokka_input )
+                .map { meta, renamed_fasta, _original_fasta, kingdom ->
+                    [ meta, renamed_fasta, kingdom ]
+                }
+            PROKKA_STANDARD( renamed_prokka_input, Channel.value("standard") )
+            PROKKA_COMPLIANT( renamed_prokka_input, Channel.value("compliant") )
+            ch_versions = ch_versions.mix(PROKKA_STANDARD.out.versions.first())
 
-        CRISPRCAS_FINDER( assemblies )
+            // Revert contig renaming in both GBK and GFF files, so they match the original FASTA
+            PROKKA_STANDARD.out.gbk
+                .mix(PROKKA_STANDARD.out.gff)
+                .mix(PROKKA_STANDARD.out.fna)
+                .groupTuple()
+                .join(SHORTEN_CONTIG_NAMES.out.fasta_ids_mapping)
+                .multiMap { meta, files_list, names_mapping ->
+                    files: [ meta, files_list ]
+                    mapping: names_mapping
+            }.set { revert_contig_renaming_input }
+            REVERT_CONTIG_RENAMING(
+                revert_contig_renaming_input.files,
+                revert_contig_renaming_input.mapping
+            )
 
-        ch_versions = ch_versions.mix(CRISPRCAS_FINDER.out.versions.first())
+            if ( params.bakta ) {
 
-        // EGGNOG_MAPPER_ORTHOLOGS - needs a third empty file in mode=mapper
-        proteins_for_emapper_orth = annotations_faa.map { it -> tuple( it[0], file(it[1]), file("NO_FILE") ) }
+                annotations_gbk = annotations_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( REVERT_CONTIG_RENAMING.out.modified_gbk )
+                annotations_gff = annotations_gff.mix( BAKTA_BAKTA.out.gff ).mix( REVERT_CONTIG_RENAMING.out.modified_gff )
+                annotations_fna = annotations_fna.mix( BAKTA_BAKTA.out.fna ).mix( REVERT_CONTIG_RENAMING.out.modified_fasta )
+                annotations_faa = annotations_faa.mix( BAKTA_BAKTA.out.faa ).mix( PROKKA_STANDARD.out.faa )
+                compliant_gbk = compliant_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( PROKKA_COMPLIANT.out.gbk )
+                compliant_gff = compliant_gff.mix( BAKTA_BAKTA.out.gff ).mix( PROKKA_COMPLIANT.out.gff )
 
-        EGGNOG_MAPPER_ORTHOLOGS(
-            proteins_for_emapper_orth,
-            Channel.value("mapper"),
-            eggnog_db
-        )
+            } else {
 
-        ch_versions = ch_versions.mix(EGGNOG_MAPPER_ORTHOLOGS.out.versions.first())
+                annotations_gbk = REVERT_CONTIG_RENAMING.out.modified_gbk
+                annotations_gff = REVERT_CONTIG_RENAMING.out.modified_gff
+                annotations_fna = REVERT_CONTIG_RENAMING.out.modified_fasta
+                annotations_faa = PROKKA_STANDARD.out.faa
 
-        // EGGNOG_MAPPER_ANNOTATIONS - needs a second empty file in mode=annotations
-        orthologs_for_annotations = assemblies.join(EGGNOG_MAPPER_ORTHOLOGS.out.orthologs, by: 0).map {
-            it -> {
-                tuple(it[0], file("NO_FILE"), file(it[2])) // tuple( meta , <empty> , assembly )
+                compliant_gbk = PROKKA_COMPLIANT.out.gbk
+                compliant_gff = PROKKA_COMPLIANT.out.gff
             }
         }
 
-        EGGNOG_MAPPER_ANNOTATIONS(
-            orthologs_for_annotations,
-            Channel.value("annotations"),
-            eggnog_db
-        )
+        if ( !params.gene_calling_only ) {
 
-        ch_versions = ch_versions.mix(EGGNOG_MAPPER_ANNOTATIONS.out.versions.first())
+            assemblies_for_quast = assemblies.join(
+                annotations_gff
+            ).map { it -> tuple(it[0], it[1], it[2]) }
 
-        if ( !params.fast ) {
-            ADD_TAXID_TO_PROTEIN_FASTA(
-                annotations_faa
+            QUAST(
+                assemblies_for_quast.map { tuple(it[0], it[1]) }, // the assembly
+                assemblies_for_quast.map { tuple(it[0], it[2]) }, // the GFF
             )
-            ch_versions = ch_versions.mix(ADD_TAXID_TO_PROTEIN_FASTA.out.versions.first())
+            ch_versions = ch_versions.mix(QUAST.out.versions.first())
 
-            INTERPROSCAN(
-                ADD_TAXID_TO_PROTEIN_FASTA.out.annotations_faa_with_taxid,
-                interproscan_db
+            PSEUDOFINDER(
+                compliant_gbk,
+                pseudofinder_db
             )
-            ch_versions = ch_versions.mix(INTERPROSCAN.out.versions.first())
+            ch_versions = ch_versions.mix(PSEUDOFINDER.out.versions.first())
 
-            UNIFIRE (
-                INTERPROSCAN.out.ips_xml
+            PSEUDOFINDER_POSTPROCESSING(
+                annotations_gff.join(
+                    compliant_gff
+                ).join(
+                    PSEUDOFINDER.out.pseudofinder_gff
+                )
             )
-            ch_versions = ch_versions.mix(UNIFIRE.out.versions.first())
-        }
+            ch_versions = ch_versions.mix(PSEUDOFINDER_POSTPROCESSING.out.versions.first())
 
-        assemblies_plus_faa_and_gff = assemblies.join(
-            annotations_faa
-        ).join(
-            annotations_gff
-        )
+            CRISPRCAS_FINDER( assemblies )
+            ch_versions = ch_versions.mix(CRISPRCAS_FINDER.out.versions.first())
 
-        AMRFINDER_PLUS_GET_SPECIES_NAME(
-            assemblies,
-            amrfinder_plus_db
-        )
+            // EGGNOG_MAPPER_ORTHOLOGS - needs a third empty file in mode=mapper
+            proteins_for_emapper_orth = annotations_faa.map { it -> tuple( it[0], file(it[1]), file("NO_FILE") ) }
 
-        AMRFINDER_PLUS(
-            assemblies_plus_faa_and_gff.join(AMRFINDER_PLUS_GET_SPECIES_NAME.out.detected_organism),
-            amrfinder_plus_db
-        )
-
-        ch_versions = ch_versions.mix(AMRFINDER_PLUS.out.versions.first())
-
-        AMRFINDER_PLUS_TSV_POSTPROCESSING(AMRFINDER_PLUS.out.amrfinder_tsv)
-
-        ch_versions = ch_versions.mix(AMRFINDER_PLUS_TSV_POSTPROCESSING.out.versions.first())
-
-        AMRFINDER_PLUS_TO_GFF( AMRFINDER_PLUS_TSV_POSTPROCESSING.out.amrfinder_tsv )
-
-        ch_versions = ch_versions.mix(AMRFINDER_PLUS_TO_GFF.out.versions.first())
-
-        DEFENSE_FINDER(
-            annotations_faa.join( annotations_gff ),
-            defense_finder_db
-        )
-
-        ch_versions = ch_versions.mix(DEFENSE_FINDER.out.versions.first())
-
-        DETECT_TRNA(
-            annotations_fna.join( LOOKUP_KINGDOM.out.detected_kingdom )
-        )
-
-        ch_versions = ch_versions.mix(DETECT_TRNA.out.versions.first())
-
-        DETECT_NCRNA(
-            annotations_fna,
-            rfam_ncrna_models
-        )
-
-        ch_versions = ch_versions.mix(DETECT_NCRNA.out.versions.first())
-
-        if ( !params.fast ) {
-            SANNTIS(
-                INTERPROSCAN.out.ips_annotations.join(annotations_gbk)
+            EGGNOG_MAPPER_ORTHOLOGS(
+                proteins_for_emapper_orth,
+                Channel.value("mapper"),
+                eggnog_db
             )
-            ch_versions = ch_versions.mix(SANNTIS.out.versions.first())
-        }
+            ch_versions = ch_versions.mix(EGGNOG_MAPPER_ORTHOLOGS.out.versions.first())
 
-
-        GECCO_RUN(
-            annotations_gbk.map { meta, gbk -> [meta, gbk, []] }, []
-        )
-
-        ch_versions = ch_versions.mix(GECCO_RUN.out.versions.first())
-
-        ANTISMASH(
-            annotations_gbk,
-            antismash_db
-        )
-
-        ch_versions = ch_versions.mix(ANTISMASH.out.versions.first())
-
-        ANTISMASH_TO_GFF(
-            ANTISMASH.out.json
-        )
-
-        ch_versions = ch_versions.mix(ANTISMASH_TO_GFF.out.versions.first())
-
-        ANTISMASH_SUMMARY(
-            ANTISMASH_TO_GFF.out.gff
-        )
-
-        ch_versions = ch_versions.mix(ANTISMASH_SUMMARY.out.versions.first())
-
-        DBCAN(
-            annotations_faa.join( annotations_gff ),
-            dbcan_db
-        )
-
-        ch_versions = ch_versions.mix(DBCAN.out.versions.first())
-
-        /**********************************************/
-        /* Combine the results into a single GFF file */
-        /**********************************************/
-        annotate_gff_input = annotations_gff.join(
-            EGGNOG_MAPPER_ANNOTATIONS.out.annotations
-        ).join(
-            DETECT_NCRNA.out.ncrna_tblout
-        ).join(
-            DETECT_TRNA.out.trna_gff
-        ).join(
-            CRISPRCAS_FINDER.out.hq_gff, remainder: true
-        ).join(
-            AMRFINDER_PLUS.out.amrfinder_tsv, remainder: true
-        ).join(
-            ANTISMASH_TO_GFF.out.gff, remainder: true
-        ).join(
-            GECCO_RUN.out.gff, remainder: true
-        ).join(
-            DBCAN.out.dbcan_gff, remainder: true
-        ).join(
-            DEFENSE_FINDER.out.gff, remainder: true
-        ).join(
-            PSEUDOFINDER_POSTPROCESSING.out.pseudofinder_processed_gff, remainder: true
-        )
-
-        if ( !params.fast ) {
-            annotate_gff_input = annotate_gff_input.join(
-                INTERPROSCAN.out.ips_annotations
-            ).join(
-                SANNTIS.out.sanntis_gff, remainder: true
-            ).join(
-                UNIFIRE.out.arba, remainder: true
-            ).join(
-                UNIFIRE.out.unirule, remainder: true
-            ).join(
-                UNIFIRE.out.pirsr, remainder: true
-            )
-        } else {
-            annotate_gff_input = annotate_gff_input.map { it -> {
-                    // IPS, SanntiS, UniFire{arba,unirule,pirsr}
-                    // meta, <files> //
-                    it + [[], [], [], [], []]
+            // EGGNOG_MAPPER_ANNOTATIONS - needs a second empty file in mode=annotations
+            orthologs_for_annotations = assemblies.join(EGGNOG_MAPPER_ORTHOLOGS.out.orthologs, by: 0).map {
+                it -> {
+                    tuple(it[0], file("NO_FILE"), file(it[2])) // tuple( meta , <empty> , assembly )
                 }
             }
-        }
 
-        ANNOTATE_GFF(
-            annotate_gff_input,
-            interpro_entry_list
-        )
+            EGGNOG_MAPPER_ANNOTATIONS(
+                orthologs_for_annotations,
+                Channel.value("annotations"),
+                eggnog_db
+            )
+            ch_versions = ch_versions.mix(EGGNOG_MAPPER_ANNOTATIONS.out.versions.first())
 
-        ch_versions = ch_versions.mix(ANNOTATE_GFF.out.versions.first())
+            if ( !params.fast ) {
+                ADD_TAXID_TO_PROTEIN_FASTA(
+                    annotations_faa
+                )
+                ch_versions = ch_versions.mix(ADD_TAXID_TO_PROTEIN_FASTA.out.versions.first())
 
-        CIRCOS_PLOT(
-            ANNOTATE_GFF.out.annotated_gff
-        )
+                INTERPROSCAN(
+                    ADD_TAXID_TO_PROTEIN_FASTA.out.annotations_faa_with_taxid,
+                    interproscan_db
+                )
+                ch_versions = ch_versions.mix(INTERPROSCAN.out.versions.first())
 
-        ch_versions = ch_versions.mix(CIRCOS_PLOT.out.versions.first())
+                UNIFIRE (
+                    INTERPROSCAN.out.ips_xml
+                )
+                ch_versions = ch_versions.mix(UNIFIRE.out.versions.first())
+            }
+
+            assemblies_plus_faa_and_gff = assemblies.join(
+                annotations_faa
+            ).join(
+                annotations_gff
+            )
+
+            AMRFINDER_PLUS_GET_SPECIES_NAME(
+                assemblies,
+                amrfinder_plus_db
+            )
+
+            AMRFINDER_PLUS(
+                assemblies_plus_faa_and_gff.join(AMRFINDER_PLUS_GET_SPECIES_NAME.out.detected_organism),
+                amrfinder_plus_db
+            )
+            ch_versions = ch_versions.mix(AMRFINDER_PLUS.out.versions.first())
+
+            AMRFINDER_PLUS_TSV_POSTPROCESSING(AMRFINDER_PLUS.out.amrfinder_tsv)
+            ch_versions = ch_versions.mix(AMRFINDER_PLUS_TSV_POSTPROCESSING.out.versions.first())
+
+            AMRFINDER_PLUS_TO_GFF( AMRFINDER_PLUS_TSV_POSTPROCESSING.out.amrfinder_tsv )
+            ch_versions = ch_versions.mix(AMRFINDER_PLUS_TO_GFF.out.versions.first())
+
+            DEFENSE_FINDER(
+                annotations_faa.join( annotations_gff ),
+                defense_finder_db
+            )
+            ch_versions = ch_versions.mix(DEFENSE_FINDER.out.versions.first())
+
+            DETECT_TRNA(
+                annotations_fna.join( LOOKUP_KINGDOM.out.detected_kingdom )
+            )
+            ch_versions = ch_versions.mix(DETECT_TRNA.out.versions.first())
+
+            DETECT_NCRNA(
+                annotations_fna,
+                rfam_ncrna_models
+            )
+            ch_versions = ch_versions.mix(DETECT_NCRNA.out.versions.first())
+
+            if ( !params.fast ) {
+                SANNTIS(
+                    INTERPROSCAN.out.ips_annotations.join(annotations_gbk)
+                )
+                ch_versions = ch_versions.mix(SANNTIS.out.versions.first())
+            }
+
+            GECCO_RUN(
+                annotations_gbk.map { meta, gbk -> [meta, gbk, []] }, []
+            )
+            ch_versions = ch_versions.mix(GECCO_RUN.out.versions.first())
+
+            ANTISMASH(
+                annotations_gbk,
+                antismash_db
+            )
+            ch_versions = ch_versions.mix(ANTISMASH.out.versions.first())
+
+            ANTISMASH_TO_GFF(
+                ANTISMASH.out.json
+            )
+
+            ch_versions = ch_versions.mix(ANTISMASH_TO_GFF.out.versions.first())
+
+            ANTISMASH_SUMMARY(
+                ANTISMASH_TO_GFF.out.gff
+            )
+            ch_versions = ch_versions.mix(ANTISMASH_SUMMARY.out.versions.first())
+
+            DBCAN(
+                annotations_faa.join( annotations_gff ),
+                dbcan_db
+            )
+            ch_versions = ch_versions.mix(DBCAN.out.versions.first())
+
+            /**********************************************/
+            /* Combine the results into a single GFF file */
+            /**********************************************/
+            annotate_gff_input = annotations_gff.join(
+                EGGNOG_MAPPER_ANNOTATIONS.out.annotations
+            ).join(
+                DETECT_NCRNA.out.ncrna_tblout
+            ).join(
+                DETECT_TRNA.out.trna_gff
+            ).join(
+                CRISPRCAS_FINDER.out.hq_gff, remainder: true
+            ).join(
+                AMRFINDER_PLUS.out.amrfinder_tsv, remainder: true
+            ).join(
+                ANTISMASH_TO_GFF.out.gff, remainder: true
+            ).join(
+                GECCO_RUN.out.gff, remainder: true
+            ).join(
+                DBCAN.out.dbcan_gff, remainder: true
+            ).join(
+                DEFENSE_FINDER.out.gff, remainder: true
+            ).join(
+                PSEUDOFINDER_POSTPROCESSING.out.pseudofinder_processed_gff, remainder: true
+            )
+
+            if ( !params.fast ) {
+                annotate_gff_input = annotate_gff_input.join(
+                    INTERPROSCAN.out.ips_annotations
+                ).join(
+                    SANNTIS.out.sanntis_gff, remainder: true
+                ).join(
+                    UNIFIRE.out.arba, remainder: true
+                ).join(
+                    UNIFIRE.out.unirule, remainder: true
+                ).join(
+                    UNIFIRE.out.pirsr, remainder: true
+                )
+            } else {
+                annotate_gff_input = annotate_gff_input.map { it -> {
+                        // IPS, SanntiS, UniFire{arba,unirule,pirsr}
+                        // meta, <files> //
+                        it + [[], [], [], [], []]
+                    }
+                }
+            }
+
+            ANNOTATE_GFF(
+                annotate_gff_input,
+                interpro_entry_list
+            )
+            ch_versions = ch_versions.mix(ANNOTATE_GFF.out.versions.first())
+
+            CIRCOS_PLOT(
+                ANNOTATE_GFF.out.annotated_gff
+            )
+            ch_versions = ch_versions.mix(CIRCOS_PLOT.out.versions.first())
+
+        } 
 
         CUSTOM_DUMPSOFTWAREVERSIONS(
             ch_versions.unique().collectFile(name: 'collated_versions.yml')
         )
 
-        //
-        // MODULE: MultiQC
-        //
-        workflow_summary    = WorkflowMettannotator.paramsSummaryMultiqc(workflow, summary_params)
-        ch_workflow_summary = Channel.value(workflow_summary)
+        if ( !params.gene_calling_only ) {
+            //
+            // MODULE: MultiQC
+            //
+            workflow_summary    = WorkflowMettannotator.paramsSummaryMultiqc(workflow, summary_params)
+            ch_workflow_summary = Channel.value(workflow_summary)
 
-        methods_description    = WorkflowMettannotator.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description, params)
-        ch_methods_description = Channel.value(methods_description)
+            methods_description    = WorkflowMettannotator.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description, params)
+            ch_methods_description = Channel.value(methods_description)
 
-        ch_multiqc_files = Channel.empty()
-        ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-        ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
-        ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-        ch_multiqc_files = ch_multiqc_files.mix( QUAST.out.results.collect { it[1] }.ifEmpty([]) )
+            ch_multiqc_files = Channel.empty()
+            ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+            ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
+            ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
+            ch_multiqc_files = ch_multiqc_files.mix( QUAST.out.results.collect { it[1] }.ifEmpty([]) )
 
 
-        MULTIQC(
-            ch_multiqc_files.collect(),
-            ch_multiqc_config.toList(),
-            ch_multiqc_custom_config.toList(),
-            ch_multiqc_logo.toList()
-        )
-        multiqc_report = MULTIQC.out.report.toList()
+            MULTIQC(
+                ch_multiqc_files.collect(),
+                ch_multiqc_config.toList(),
+                ch_multiqc_custom_config.toList(),
+                ch_multiqc_logo.toList()
+            )
+            multiqc_report = MULTIQC.out.report.toList()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR extends the pipeline with three complementary mechanisms for supplying gene calls, adds two-phase annotation support, and includes several bug fixes and safety guards. 

The mettannotator.nf is still not organised by separate sub-workflows, I plan to implement this in a next PR. 

---

## New features

### 1. Gene-calling-only mode (`--gene_calling_only`)

Stops the pipeline after Prokka/Bakta and kingdom lookup, publishing gene-calling outputs to `<outdir>/functional_annotation/{prokka,bakta}/`. Useful for inspecting or filtering gene calls before committing to a full annotation run.

Incompatible with: `--fast`, `--add_slow_tools`.

### 2. Reuse existing gene calls (`--gene_calls <dir>`)

Skips Prokka/Bakta entirely and discovers gene-calling outputs from a previous mettannotator run by sample prefix under the supplied directory. Both Prokka and Bakta outputs are supported.

Incompatible with: `--fast`, `--add_slow_tools`, samplesheet `gene_calls_gff` column.

### 3. Per-sample external gene calls (samplesheet columns)

Four optional samplesheet columns let individual samples bypass gene calling using externally-produced files:

| Column | Description |
|--------|-------------|
| `gene_calls_gff` | GFF/GFF3 with CDS features (anchor field) |
| `gene_calls_faa` | Matching protein FASTA — required when `gene_calls_gff` is set |
| `annotation_source` | `prokka`, `bakta`, or `ensembl` — required when `gene_calls_gff` is set |
| `gene_calls_gbk` | Optional GenBank; enables Pseudofinder, GECCO, antiSMASH, SanntiS |

Standard (3-column) and extended rows can coexist in the same samplesheet. For `annotation_source=ensembl`, the GFF3 is normalised automatically (see below). If `gene_calls_gbk` is omitted for an Ensembl sample, a GenBank is generated automatically; providing it skips that step.

### 4. Ensembl Bacteria GFF3 support

A new `normalize_ensembl_gff.py` script (wrapped by the `NORMALIZE_ENSEMBL_GFF` module) converts raw Ensembl Bacteria GFF3 to Prokka-style GFF3 before annotation. Problems addressed: `CDS:` prefix on protein IDs (breaks annotation lookups), missing `locus_tag` and `product` attributes, non-standard `#!` pragma headers, and `###` separator lines.

A new `GFF_TO_GBK` module generates a GenBank file from the normalised GFF using `gbk_generator` from mgnify-pipelines-toolkit. Gene and CDS features share `locus_tag` but CDS carry no `Parent=` attribute — this matches Prokka's GBK convention and ensures `/translation=` qualifiers are written correctly by BCBio.

---

## Groovy validation safeguards

All checks run at pipeline startup, before any jobs are submitted.

`MettannotatorValidation.validateExternalGeneCalls()` fires when the samplesheet contains a `gene_calls_gff` column:

- `gene_calls_faa`, `gene_calls_gbk`, or `annotation_source` set without `gene_calls_gff` (anchor field missing)
- `gene_calls_gff` set but `annotation_source` absent or not one of `prokka`, `bakta`, `ensembl`
- `gene_calls_gff` set but `gene_calls_faa` absent
- Any of `gene_calls_gff`, `gene_calls_faa`, `gene_calls_gbk` pointing to a non-existent file

`main.nf` mutual exclusion checks:

- `--gene_calls` + samplesheet `gene_calls_gff` column → error
- `--gene_calling_only` + `--fast` → error
- `--gene_calling_only` + `--add_slow_tools` → error
- `--gene_calls` + `--add_slow_tools` → error

`MettannotatorValidation.validateFastRunInputs()` fires with `--add_slow_tools`:

- Verifies required per-sample files exist in the fast-run output directory
- Checks pipeline version consistency; errors if mismatch unless `--ignore_version_mismatch`

---

## Bug fixes

- **`product_source=Ensembl` for Ensembl samples** — `add_hypothetical_protein_descriptions.py` was hardcoding `GeneCaller.PROKKA` regardless of actual annotation source. Added `--annotation-source` flag and threaded it through `annotate_gff/main.nf` via `meta.annotation_source`.
- **UNIFIRE crash on long protein descriptions** — InterProScan truncates XML name attributes at 255 characters. A long description could push `OX=<taxid>` past that limit, producing a malformed taxid (e.g. `OX=1523156` becomes `OX=15`) that UNIFIRE rejects. Descriptions are now truncated in `add_taxid_to_faa.py` so `OX=` always falls within the budget.

---
