### PR TITLE
Feature/subworkflow refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ maximum length is 24 characters; the prefix may contain letters, digits, dashes,
 
 To use pre-computed gene calls for individual samples, add up to four optional columns:
 
-| Column | Description |
-|--------|-------------|
-| `gene_calls_gff` | GFF/GFF3 file with CDS features (anchor field) |
-| `gene_calls_faa` | Matching protein FASTA — required when `gene_calls_gff` is set |
+| Column              | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `gene_calls_gff`    | GFF/GFF3 file with CDS features (anchor field)                                         |
+| `gene_calls_faa`    | Matching protein FASTA — required when `gene_calls_gff` is set                         |
 | `annotation_source` | Source format: `prokka`, `bakta`, or `ensembl` — required when `gene_calls_gff` is set |
-| `gene_calls_gbk` | Optional GenBank file; enables Pseudofinder, GECCO, antiSMASH, and SanntiS |
+| `gene_calls_gbk`    | Optional GenBank file; enables Pseudofinder, GECCO, antiSMASH, and SanntiS             |
 
 Samples without external gene calls leave these columns empty. Standard (3-column) and extended-column rows can coexist in the same samplesheet.
 

--- a/bin/add_hypothetical_protein_descriptions.py
+++ b/bin/add_hypothetical_protein_descriptions.py
@@ -34,7 +34,15 @@ class GeneCaller(Enum):
     ENSEMBL = "Ensembl"
 
 
-def main(ipr_types_file, ipr_file, hierarchy_file, eggnog_file, infile, outfile, annotation_source="prokka"):
+def main(
+    ipr_types_file,
+    ipr_file,
+    hierarchy_file,
+    eggnog_file,
+    infile,
+    outfile,
+    annotation_source="prokka",
+):
     eggnog_info = load_eggnog(eggnog_file)
     if ipr_file:
         levels = load_hierarchy(hierarchy_file)

--- a/bin/normalize_ensembl_gff.py
+++ b/bin/normalize_ensembl_gff.py
@@ -10,15 +10,29 @@
 # Output: standard Prokka-style GFF3 with ID, locus_tag, product on every CDS.
 
 import argparse
-import urllib.parse
 import sys
+import urllib.parse
 
 SKIP_FEATURES = {
-    "mRNA", "exon", "pseudogene", "pseudogenic_transcript",
-    "ncRNA_gene", "ncRNA", "pre_miRNA", "miRNA", "snoRNA", "snRNA",
-    "lnc_RNA", "antisense_RNA", "ribozyme",
-    "rRNA", "tRNA", "biological_region", "chromosome",
-    "region", "tmRNA",
+    "mRNA",
+    "exon",
+    "pseudogene",
+    "pseudogenic_transcript",
+    "ncRNA_gene",
+    "ncRNA",
+    "pre_miRNA",
+    "miRNA",
+    "snoRNA",
+    "snRNA",
+    "lnc_RNA",
+    "antisense_RNA",
+    "ribozyme",
+    "rRNA",
+    "tRNA",
+    "biological_region",
+    "chromosome",
+    "region",
+    "tmRNA",
 }
 
 
@@ -50,8 +64,8 @@ def decode_description(text):
 
 
 def normalise(in_gff, out_gff):
-    gene_info    = {}   # gene_id  -> {"name": str|None, "description": str|None}
-    mrna_to_gene = {}   # transcript_id -> gene_id
+    gene_info = {}  # gene_id  -> {"name": str|None, "description": str|None}
+    mrna_to_gene = {}  # transcript_id -> gene_id
 
     # --- Pass 1: collect gene and mRNA metadata ---
     with open(in_gff) as fh:
@@ -63,19 +77,21 @@ def normalise(in_gff, out_gff):
             if len(cols) != 9:
                 continue
             feature = cols[2]
-            attrs   = col9_to_dict(cols[8])
+            attrs = col9_to_dict(cols[8])
 
             if feature == "gene":
                 # gene_id attribute is the stable identifier (e.g. ABAYE0001)
-                gid  = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
+                gid = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
                 desc = decode_description(attrs.get("description", ""))
                 name = attrs.get("Name")
                 gene_info[gid] = {"name": name, "description": desc or None}
 
             elif feature == "mRNA":
-                tid        = attrs.get("transcript_id") or attrs.get("ID", "").removeprefix("transcript:")
+                tid = attrs.get("transcript_id") or attrs.get("ID", "").removeprefix(
+                    "transcript:"
+                )
                 parent_raw = attrs.get("Parent", "")
-                gid        = parent_raw.removeprefix("gene:")
+                gid = parent_raw.removeprefix("gene:")
                 if tid and gid:
                     mrna_to_gene[tid] = gid
 
@@ -93,7 +109,9 @@ def normalise(in_gff, out_gff):
 
             if line.startswith("#"):
                 # Keep standard GFF3 directives; drop Ensembl-specific pragmas (#!...)
-                if line.startswith("##gff-version") or line.startswith("##sequence-region"):
+                if line.startswith("##gff-version") or line.startswith(
+                    "##sequence-region"
+                ):
                     out.write(line + "\n")
                 continue
 
@@ -107,9 +125,9 @@ def normalise(in_gff, out_gff):
                 continue
 
             if feature == "gene":
-                attrs  = col9_to_dict(cols[8])
-                gid    = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
-                name   = attrs.get("Name")
+                attrs = col9_to_dict(cols[8])
+                gid = attrs.get("gene_id") or attrs.get("ID", "").removeprefix("gene:")
+                name = attrs.get("Name")
                 # Match Prokka compliant format: gene ID gets _gene suffix so CDS can
                 # reference it via Parent=<gid>_gene
                 new_attrs = [("ID", f"{gid}_gene"), ("locus_tag", gid)]
@@ -143,11 +161,11 @@ def normalise(in_gff, out_gff):
                 continue
 
             # Resolve gene info via transcript → gene chain
-            tid       = attrs.get("Parent", "").removeprefix("transcript:")
-            gid       = mrna_to_gene.get(tid, "")
+            tid = attrs.get("Parent", "").removeprefix("transcript:")
+            gid = mrna_to_gene.get(tid, "")
             gene_meta = gene_info.get(gid, {})
 
-            product   = gene_meta.get("description") or "hypothetical protein"
+            product = gene_meta.get("description") or "hypothetical protein"
             gene_name = gene_meta.get("name")
 
             # Build clean Prokka-compliant attributes.
@@ -155,9 +173,9 @@ def normalise(in_gff, out_gff):
             # gbk_generator to omit CDS from the GBK (it only iterates top-level features).
             # Gene + CDS are linked implicitly by shared locus_tag, matching Prokka's GBK format.
             new_attrs = [
-                ("ID",        protein_id),
+                ("ID", protein_id),
                 ("locus_tag", gid if gid else protein_id),
-                ("product",   product),
+                ("product", product),
             ]
             if gene_name:
                 new_attrs.append(("Name", gene_name))
@@ -170,7 +188,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Normalise an Ensembl Bacteria GFF3 for mettannotator."
     )
-    parser.add_argument("-i", "--input",  required=True, help="Input Ensembl GFF3")
+    parser.add_argument("-i", "--input", required=True, help="Input Ensembl GFF3")
     parser.add_argument("-o", "--output", required=True, help="Output normalised GFF3")
     args = parser.parse_args()
     normalise(args.input, args.output)

--- a/subworkflows/fast_annotation.nf
+++ b/subworkflows/fast_annotation.nf
@@ -1,0 +1,120 @@
+include { AMRFINDER_PLUS_GET_SPECIES_NAME            } from '../modules/local/amrfinder_plus'
+include { AMRFINDER_PLUS; AMRFINDER_PLUS_TO_GFF      } from '../modules/local/amrfinder_plus'
+include { AMRFINDER_PLUS_TSV_POSTPROCESSING          } from '../modules/local/amrfinder_plus'
+include { DEFENSE_FINDER                             } from '../modules/local/defense_finder'
+include { CRISPRCAS_FINDER                           } from '../modules/local/crisprcasfinder'
+include { EGGNOG_MAPPER as EGGNOG_MAPPER_ORTHOLOGS   } from '../modules/local/eggnog'
+include { EGGNOG_MAPPER as EGGNOG_MAPPER_ANNOTATIONS } from '../modules/local/eggnog'
+include { DETECT_TRNA                                } from '../modules/local/detect_trna'
+include { DETECT_NCRNA                               } from '../modules/local/detect_ncrna'
+include { ANTISMASH                                  } from '../modules/local/antismash'
+include { ANTISMASH_TO_GFF                           } from '../modules/local/antismash'
+include { ANTISMASH_SUMMARY                          } from '../modules/local/antismash'
+include { DBCAN                                      } from '../modules/local/dbcan'
+include { PSEUDOFINDER                               } from '../modules/local/pseudofinder'
+include { PSEUDOFINDER_POSTPROCESSING                } from '../modules/local/pseudofinder'
+include { GECCO_RUN                                  } from '../modules/nf-core/gecco/run/main'
+include { QUAST                                      } from '../modules/nf-core/quast/main'
+
+workflow FAST_ANNOTATION {
+
+    take:
+    faa              // channel: [meta, faa]
+    gff              // channel: [meta, gff]
+    gbk              // channel: [meta, gbk]
+    fna              // channel: [meta, fna]
+    compliant_gbk    // channel: [meta, compliant_gbk]
+    compliant_gff    // channel: [meta, compliant_gff]
+    assemblies       // channel: [meta, assembly]
+    detected_kingdom // channel: [meta, kingdom]
+    amrfinder_plus_db
+    antismash_db
+    defense_finder_db
+    dbcan_db
+    eggnog_db
+    rfam_ncrna_models
+    pseudofinder_db
+
+    main:
+    ch_versions = Channel.empty()
+
+    assemblies_and_gff = assemblies.join(gff)
+    QUAST(
+        assemblies_and_gff.map { meta, assembly, _gff     -> [meta, assembly]  },
+        assemblies_and_gff.map { meta, _assembly, gff_file -> [meta, gff_file] }
+    )
+    ch_versions = ch_versions.mix(QUAST.out.versions.first())
+
+    PSEUDOFINDER(compliant_gbk, pseudofinder_db)
+    ch_versions = ch_versions.mix(PSEUDOFINDER.out.versions.first())
+
+    PSEUDOFINDER_POSTPROCESSING(
+        gff.join(compliant_gff).join(PSEUDOFINDER.out.pseudofinder_gff)
+    )
+    ch_versions = ch_versions.mix(PSEUDOFINDER_POSTPROCESSING.out.versions.first())
+
+    CRISPRCAS_FINDER(assemblies)
+    ch_versions = ch_versions.mix(CRISPRCAS_FINDER.out.versions.first())
+
+    proteins_for_emapper_orth = faa.map { meta, faa_file -> tuple(meta, file(faa_file), file("NO_FILE")) }
+    EGGNOG_MAPPER_ORTHOLOGS(proteins_for_emapper_orth, Channel.value("mapper"), eggnog_db)
+    ch_versions = ch_versions.mix(EGGNOG_MAPPER_ORTHOLOGS.out.versions.first())
+
+    orthologs_for_annotations = assemblies.join(EGGNOG_MAPPER_ORTHOLOGS.out.orthologs).map {
+        meta, _assembly, orthologs -> tuple(meta, file("NO_FILE"), file(orthologs))
+    }
+    EGGNOG_MAPPER_ANNOTATIONS(orthologs_for_annotations, Channel.value("annotations"), eggnog_db)
+    ch_versions = ch_versions.mix(EGGNOG_MAPPER_ANNOTATIONS.out.versions.first())
+
+    AMRFINDER_PLUS_GET_SPECIES_NAME(assemblies, amrfinder_plus_db)
+
+    AMRFINDER_PLUS(
+        assemblies.join(faa).join(gff).join(AMRFINDER_PLUS_GET_SPECIES_NAME.out.detected_organism),
+        amrfinder_plus_db
+    )
+    ch_versions = ch_versions.mix(AMRFINDER_PLUS.out.versions.first())
+
+    AMRFINDER_PLUS_TSV_POSTPROCESSING(AMRFINDER_PLUS.out.amrfinder_tsv)
+    ch_versions = ch_versions.mix(AMRFINDER_PLUS_TSV_POSTPROCESSING.out.versions.first())
+
+    AMRFINDER_PLUS_TO_GFF(AMRFINDER_PLUS_TSV_POSTPROCESSING.out.amrfinder_tsv)
+    ch_versions = ch_versions.mix(AMRFINDER_PLUS_TO_GFF.out.versions.first())
+
+    DEFENSE_FINDER(faa.join(gff), defense_finder_db)
+    ch_versions = ch_versions.mix(DEFENSE_FINDER.out.versions.first())
+
+    DETECT_TRNA(fna.join(detected_kingdom))
+    ch_versions = ch_versions.mix(DETECT_TRNA.out.versions.first())
+
+    DETECT_NCRNA(fna, rfam_ncrna_models)
+    ch_versions = ch_versions.mix(DETECT_NCRNA.out.versions.first())
+
+    GECCO_RUN(gbk.map { meta, gbk_file -> [meta, gbk_file, []] }, [])
+    ch_versions = ch_versions.mix(GECCO_RUN.out.versions.first())
+
+    ANTISMASH(gbk, antismash_db)
+    ch_versions = ch_versions.mix(ANTISMASH.out.versions.first())
+
+    ANTISMASH_TO_GFF(ANTISMASH.out.json)
+    ch_versions = ch_versions.mix(ANTISMASH_TO_GFF.out.versions.first())
+
+    ANTISMASH_SUMMARY(ANTISMASH_TO_GFF.out.gff)
+    ch_versions = ch_versions.mix(ANTISMASH_SUMMARY.out.versions.first())
+
+    DBCAN(faa.join(gff), dbcan_db)
+    ch_versions = ch_versions.mix(DBCAN.out.versions.first())
+
+    emit:
+    eggnog_annotations = EGGNOG_MAPPER_ANNOTATIONS.out.annotations
+    ncrna_tblout       = DETECT_NCRNA.out.ncrna_tblout
+    trna_gff           = DETECT_TRNA.out.trna_gff
+    crisprcas_hq_gff   = CRISPRCAS_FINDER.out.hq_gff
+    amrfinder_tsv      = AMRFINDER_PLUS.out.amrfinder_tsv
+    antismash_gff      = ANTISMASH_TO_GFF.out.gff
+    gecco_gff          = GECCO_RUN.out.gff
+    dbcan_gff          = DBCAN.out.dbcan_gff
+    defense_gff        = DEFENSE_FINDER.out.gff
+    pseudofinder_gff   = PSEUDOFINDER_POSTPROCESSING.out.pseudofinder_processed_gff
+    quast_results      = QUAST.out.results
+    versions           = ch_versions
+}

--- a/subworkflows/gene_calling.nf
+++ b/subworkflows/gene_calling.nf
@@ -1,0 +1,218 @@
+include { LOOKUP_KINGDOM                             } from '../modules/local/lookup_kingdom'
+include { PROKKA as PROKKA_STANDARD                  } from '../modules/local/prokka'
+include { PROKKA as PROKKA_COMPLIANT                 } from '../modules/local/prokka'
+include { RENAME_CONTIGS as SHORTEN_CONTIG_NAMES     } from '../modules/local/rename_contigs'
+include { RENAME_CONTIGS as REVERT_CONTIG_RENAMING   } from '../modules/local/rename_contigs'
+include { BAKTA_BAKTA                                } from '../modules/nf-core/bakta/bakta/main'
+include { NORMALIZE_ENSEMBL_GFF                      } from '../modules/local/normalize_ensembl_gff'
+include { GFF_TO_GBK                                 } from '../modules/local/gff_to_gbk'
+
+workflow GENE_CALLING {
+
+    take:
+    assemblies_raw  // channel: full rows from fromSamplesheet [meta, assembly, gff, faa, gbk]
+    assemblies      // channel: [meta, assembly]
+    bakta_db        // channel: path (ignored when !params.bakta)
+
+    main:
+    ch_versions     = Channel.empty()
+    annotations_fna = channel.empty()
+    annotations_gbk = channel.empty()
+    annotations_faa = channel.empty()
+    annotations_gff = channel.empty()
+    compliant_gbk   = channel.empty()
+    compliant_gff   = channel.empty()
+
+    // ------------------------------------------------------------------
+    // Per-sample external gene calls from samplesheet columns
+    // ------------------------------------------------------------------
+    // Tuple: [meta, assembly, gene_calls_gff, gene_calls_faa, gene_calls_gbk]
+    // When the gene_calls_gff column is absent, this channel is empty.
+    ext_gene_call_rows = assemblies_raw
+        .filter { it[0].annotation_source in ['prokka', 'bakta', 'ensembl'] }
+        .map { [it[0], it[1], it[2], it[3], it[4]] }
+
+    ext_gene_call_rows.branch {
+        ensembl: it[0].annotation_source == 'ensembl'
+        direct:  true   // prokka or bakta — GFF used as-is
+    }.set { ext_gc_branches }
+
+    NORMALIZE_ENSEMBL_GFF(
+        ext_gc_branches.ensembl.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
+    )
+    ch_versions = ch_versions.mix(NORMALIZE_ENSEMBL_GFF.out.versions)
+
+    // Ensembl samples with a user-supplied GBK skip GFF_TO_GBK.
+    ext_gc_branches.ensembl.branch {
+        has_gbk:   it[4]
+        needs_gbk: true
+    }.set { ensembl_gbk_branches }
+
+    GFF_TO_GBK(
+        NORMALIZE_ENSEMBL_GFF.out.normalised_gff
+            .join( ensembl_gbk_branches.needs_gbk.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
+            .join( ensembl_gbk_branches.needs_gbk.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
+    )
+    ch_versions = ch_versions.mix(GFF_TO_GBK.out.versions)
+
+    ext_annotations_gff = NORMALIZE_ENSEMBL_GFF.out.normalised_gff
+        .mix( ext_gc_branches.direct.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] } )
+    ext_annotations_faa = ext_gc_branches.ensembl.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] }
+        .mix( ext_gc_branches.direct.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
+    ext_annotations_fna = ext_gc_branches.ensembl.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] }
+        .mix( ext_gc_branches.direct.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
+
+    // Any external sample that provides a GBK uses it directly (bypasses GFF_TO_GBK).
+    ext_gbk = ensembl_gbk_branches.has_gbk
+        .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] }
+        .mix( ext_gc_branches.direct
+            .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
+            .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] } )
+    ext_direct_compliant_gff = ext_gc_branches.direct
+        .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
+        .map    { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
+
+    // ------------------------------------------------------------------
+    // Kingdom lookup (needed for Prokka/Bakta routing and tRNA downstream)
+    // ------------------------------------------------------------------
+    LOOKUP_KINGDOM( assemblies )
+    ch_versions = ch_versions.mix(LOOKUP_KINGDOM.out.versions.first())
+
+    assemblies_with_kingdom = assemblies.join( LOOKUP_KINGDOM.out.detected_kingdom )
+
+    // ------------------------------------------------------------------
+    // Gene calling: --gene_calls (directory), or Prokka / Bakta
+    // ------------------------------------------------------------------
+    if ( params.gene_calls ) {
+
+        def gene_calls_dir = file(params.gene_calls)
+
+        def load_files = { pattern, strip_suffix ->
+            channel
+                .fromPath(pattern, checkIfExists: false)
+                .map { f ->
+                    def name = f.name.replaceAll(strip_suffix + '$', '')
+                    tuple(name, f)
+                }
+        }
+
+        // Preserve the original samplesheet meta (needed for downstream joins)
+        assemblies_by_prefix = assemblies.map { meta, assembly -> [meta.prefix, meta] }
+
+        // Load annotation files from the appropriate tool's output directory.
+        // Prokka: .faa / .gbk / .gff / .fna   Bakta: .faa / .gbff / .gff3 / .fna
+        if ( params.bakta ) {
+            gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.faa",   '\\.faa')
+            gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
+            gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
+            gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.fna",   '\\.fna')
+            gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
+            gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
+        } else {
+            gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.faa",            '\\.faa')
+            gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gbk",            '\\.gbk')
+            gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gff",            '\\.gff')
+            gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.fna",            '\\.fna')
+            gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gbk", '\\.gbk')
+            gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gff", '\\.gff')
+        }
+
+        annotations_faa  = assemblies_by_prefix.join(gc_faa).map           { prefix, meta, f -> tuple(meta, f) }
+        annotations_gbk  = assemblies_by_prefix.join(gc_gbk).map           { prefix, meta, f -> tuple(meta, f) }
+        annotations_gff  = assemblies_by_prefix.join(gc_gff).map           { prefix, meta, f -> tuple(meta, f) }
+        annotations_fna  = assemblies_by_prefix.join(gc_fna).map           { prefix, meta, f -> tuple(meta, f) }
+        compliant_gbk    = assemblies_by_prefix.join(gc_compliant_gbk).map { prefix, meta, f -> tuple(meta, f) }
+        compliant_gff    = assemblies_by_prefix.join(gc_compliant_gff).map { prefix, meta, f -> tuple(meta, f) }
+
+    } else {
+
+        // Exclude samples that supply per-sample external gene calls from Prokka/Bakta
+        assemblies_for_gene_calling = assemblies_with_kingdom.filter { meta, _assembly, _kingdom ->
+            !(meta.annotation_source in ['prokka', 'bakta', 'ensembl'])
+        }
+
+        if ( params.bakta ) {
+
+            assemblies_for_gene_calling.branch {
+                bacteria: it[2] == "Bacteria"
+                archaea:  it[2] == "Archaea"
+            }.set { assemblies_to_annotate }
+
+            BAKTA_BAKTA( assemblies_to_annotate.bacteria, bakta_db )
+            ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions.first())
+
+            prokka_input = assemblies_to_annotate.archaea
+
+        } else {
+
+            prokka_input = assemblies_for_gene_calling
+
+        }
+
+        // Prokka crashes with long contig names — temporarily rename before running
+        SHORTEN_CONTIG_NAMES(
+            prokka_input.map { meta, fasta, _kingdom -> [ meta, fasta ] },
+            []
+        )
+        ch_versions = ch_versions.mix(SHORTEN_CONTIG_NAMES.out.versions.first())
+
+        renamed_prokka_input = SHORTEN_CONTIG_NAMES.out.modified_fasta
+            .join( prokka_input )
+            .map { meta, renamed_fasta, _original_fasta, kingdom -> [ meta, renamed_fasta, kingdom ] }
+
+        PROKKA_STANDARD( renamed_prokka_input, Channel.value("standard") )
+        PROKKA_COMPLIANT( renamed_prokka_input, Channel.value("compliant") )
+        ch_versions = ch_versions.mix(PROKKA_STANDARD.out.versions.first())
+
+        // Revert contig renaming so GBK/GFF match the original FASTA
+        PROKKA_STANDARD.out.gbk
+            .mix(PROKKA_STANDARD.out.gff)
+            .mix(PROKKA_STANDARD.out.fna)
+            .groupTuple()
+            .join(SHORTEN_CONTIG_NAMES.out.fasta_ids_mapping)
+            .multiMap { meta, files_list, names_mapping ->
+                files:   [ meta, files_list ]
+                mapping: names_mapping
+            }.set { revert_contig_renaming_input }
+
+        REVERT_CONTIG_RENAMING(
+            revert_contig_renaming_input.files,
+            revert_contig_renaming_input.mapping
+        )
+
+        if ( params.bakta ) {
+            annotations_gbk = annotations_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( REVERT_CONTIG_RENAMING.out.modified_gbk )
+            annotations_gff = annotations_gff.mix( BAKTA_BAKTA.out.gff ).mix( REVERT_CONTIG_RENAMING.out.modified_gff )
+            annotations_fna = annotations_fna.mix( BAKTA_BAKTA.out.fna ).mix( REVERT_CONTIG_RENAMING.out.modified_fasta )
+            annotations_faa = annotations_faa.mix( BAKTA_BAKTA.out.faa ).mix( PROKKA_STANDARD.out.faa )
+            compliant_gbk   = compliant_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( PROKKA_COMPLIANT.out.gbk )
+            compliant_gff   = compliant_gff.mix( BAKTA_BAKTA.out.gff ).mix( PROKKA_COMPLIANT.out.gff )
+        } else {
+            annotations_gbk = REVERT_CONTIG_RENAMING.out.modified_gbk
+            annotations_gff = REVERT_CONTIG_RENAMING.out.modified_gff
+            annotations_fna = REVERT_CONTIG_RENAMING.out.modified_fasta
+            annotations_faa = PROKKA_STANDARD.out.faa
+            compliant_gbk   = PROKKA_COMPLIANT.out.gbk
+            compliant_gff   = PROKKA_COMPLIANT.out.gff
+        }
+    }
+
+    // Mix per-sample external gene calls into the main annotation channels.
+    // Empty no-op when no external gene calls are provided.
+    annotations_gff = annotations_gff.mix(ext_annotations_gff)
+    annotations_faa = annotations_faa.mix(ext_annotations_faa)
+    annotations_fna = annotations_fna.mix(ext_annotations_fna)
+    annotations_gbk = annotations_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
+    compliant_gbk   = compliant_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
+    compliant_gff   = compliant_gff.mix(NORMALIZE_ENSEMBL_GFF.out.normalised_gff).mix(ext_direct_compliant_gff)
+
+    emit:
+    annotations_faa  = annotations_faa
+    annotations_gff  = annotations_gff
+    annotations_gbk  = annotations_gbk
+    annotations_fna  = annotations_fna
+    compliant_gbk    = compliant_gbk
+    compliant_gff    = compliant_gff
+    detected_kingdom = LOOKUP_KINGDOM.out.detected_kingdom
+    versions         = ch_versions
+}

--- a/subworkflows/slow_annotation.nf
+++ b/subworkflows/slow_annotation.nf
@@ -1,0 +1,35 @@
+include { ADD_TAXID_TO_PROTEIN_FASTA } from '../modules/local/add_taxid'
+include { INTERPROSCAN               } from '../modules/local/interproscan'
+include { UNIFIRE                    } from '../modules/local/unifire'
+include { SANNTIS                    } from '../modules/local/sanntis'
+
+workflow SLOW_ANNOTATION {
+
+    take:
+    faa             // channel: [meta, faa]
+    gbk             // channel: [meta, gbk]
+    interproscan_db // channel: path
+
+    main:
+    ch_versions = Channel.empty()
+
+    ADD_TAXID_TO_PROTEIN_FASTA(faa)
+    ch_versions = ch_versions.mix(ADD_TAXID_TO_PROTEIN_FASTA.out.versions.first())
+
+    INTERPROSCAN(ADD_TAXID_TO_PROTEIN_FASTA.out.annotations_faa_with_taxid, interproscan_db)
+    ch_versions = ch_versions.mix(INTERPROSCAN.out.versions.first())
+
+    UNIFIRE(INTERPROSCAN.out.ips_xml)
+    ch_versions = ch_versions.mix(UNIFIRE.out.versions.first())
+
+    SANNTIS(INTERPROSCAN.out.ips_annotations.join(gbk))
+    ch_versions = ch_versions.mix(SANNTIS.out.versions.first())
+
+    emit:
+    ips_annotations = INTERPROSCAN.out.ips_annotations
+    sanntis_gff     = SANNTIS.out.sanntis_gff
+    arba            = UNIFIRE.out.arba
+    unirule         = UNIFIRE.out.unirule
+    pirsr           = UNIFIRE.out.pirsr
+    versions        = ch_versions
+}

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -23,12 +23,8 @@ include { DEFENSE_FINDER                             } from '../modules/local/de
 include { CRISPRCAS_FINDER                           } from '../modules/local/crisprcasfinder'
 include { EGGNOG_MAPPER as EGGNOG_MAPPER_ORTHOLOGS   } from '../modules/local/eggnog'
 include { EGGNOG_MAPPER as EGGNOG_MAPPER_ANNOTATIONS } from '../modules/local/eggnog'
-include { ADD_TAXID_TO_PROTEIN_FASTA                 } from '../modules/local/add_taxid'
-include { INTERPROSCAN                               } from '../modules/local/interproscan'
 include { DETECT_TRNA                                } from '../modules/local/detect_trna'
 include { DETECT_NCRNA                               } from '../modules/local/detect_ncrna'
-include { SANNTIS                                    } from '../modules/local/sanntis'
-include { UNIFIRE                                    } from '../modules/local/unifire'
 include { ANNOTATE_GFF                               } from '../modules/local/annotate_gff'
 include { ANTISMASH                                  } from '../modules/local/antismash'
 include { ANTISMASH_TO_GFF                           } from '../modules/local/antismash'
@@ -43,6 +39,7 @@ include { GFF_TO_GBK                                 } from '../modules/local/gf
 
 
 include { DOWNLOAD_DATABASES                         } from '../subworkflows/download_databases'
+include { SLOW_ANNOTATION                            } from '../subworkflows/slow_annotation'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -207,10 +204,8 @@ workflow METTANNOTATOR {
         //
         // In add-slow-tools mode, we read existing results from --fast and run only slow tools
         //
-        Channel.fromSamplesheet("input")
-                     .map { meta, assembly ->
-                        [meta.prefix, meta.taxid]
-                    }
+       Channel.fromSamplesheet("input")
+                    .map { row -> [row[0].prefix, row[0].taxid] }
                     .set { samplesheet }
 
         def results_dir = file(params.add_slow_tools)
@@ -275,34 +270,15 @@ workflow METTANNOTATOR {
             }
             .set { annotations_gbk }
 
-        // For InterProScan, we need to add taxid to the protein FASTA
-        ADD_TAXID_TO_PROTEIN_FASTA(
-            annotations_faa_input
-        )
-        ch_versions = ch_versions.mix(ADD_TAXID_TO_PROTEIN_FASTA.out.versions.first())
+        SLOW_ANNOTATION(annotations_faa_input, annotations_gbk, interproscan_db)
+        ch_versions = ch_versions.mix(SLOW_ANNOTATION.out.versions)
 
-        INTERPROSCAN(
-            ADD_TAXID_TO_PROTEIN_FASTA.out.annotations_faa_with_taxid,
-            interproscan_db
-        )
-        ch_versions = ch_versions.mix(INTERPROSCAN.out.versions.first())
-
-        UNIFIRE (
-            INTERPROSCAN.out.ips_xml
-        )
-        ch_versions = ch_versions.mix(UNIFIRE.out.versions.first())
-
-        SANNTIS(
-           INTERPROSCAN.out.ips_annotations.join(annotations_gbk)
-        )
-        ch_versions = ch_versions.mix(SANNTIS.out.versions.first())
-
-        // Re-key slow tool outputs by prefix string for joining
-        ips_by_prefix     = INTERPROSCAN.out.ips_annotations.map { meta, f -> [meta.prefix, f] }
-        sanntis_by_prefix = SANNTIS.out.sanntis_gff.map         { meta, f -> [meta.prefix, f] }
-        arba_by_prefix    = UNIFIRE.out.arba.map                { meta, f -> [meta.prefix, f] }
-        unirule_by_prefix = UNIFIRE.out.unirule.map             { meta, f -> [meta.prefix, f] }
-        pirsr_by_prefix   = UNIFIRE.out.pirsr.map               { meta, f -> [meta.prefix, f] }
+        // Re-key slow tool outputs by prefix string for joining with disk-loaded fast results
+        ips_by_prefix     = SLOW_ANNOTATION.out.ips_annotations.map { meta, f -> [meta.prefix, f] }
+        sanntis_by_prefix = SLOW_ANNOTATION.out.sanntis_gff.map     { meta, f -> [meta.prefix, f] }
+        arba_by_prefix    = SLOW_ANNOTATION.out.arba.map            { meta, f -> [meta.prefix, f] }
+        unirule_by_prefix = SLOW_ANNOTATION.out.unirule.map         { meta, f -> [meta.prefix, f] }
+        pirsr_by_prefix   = SLOW_ANNOTATION.out.pirsr.map           { meta, f -> [meta.prefix, f] }
 
         // Build fast results channel keyed by prefix
         fast_results = samplesheet
@@ -598,21 +574,8 @@ workflow METTANNOTATOR {
             ch_versions = ch_versions.mix(EGGNOG_MAPPER_ANNOTATIONS.out.versions.first())
 
             if ( !params.fast ) {
-                ADD_TAXID_TO_PROTEIN_FASTA(
-                    annotations_faa
-                )
-                ch_versions = ch_versions.mix(ADD_TAXID_TO_PROTEIN_FASTA.out.versions.first())
-
-                INTERPROSCAN(
-                    ADD_TAXID_TO_PROTEIN_FASTA.out.annotations_faa_with_taxid,
-                    interproscan_db
-                )
-                ch_versions = ch_versions.mix(INTERPROSCAN.out.versions.first())
-
-                UNIFIRE (
-                    INTERPROSCAN.out.ips_xml
-                )
-                ch_versions = ch_versions.mix(UNIFIRE.out.versions.first())
+                SLOW_ANNOTATION(annotations_faa, annotations_gbk, interproscan_db)
+                ch_versions = ch_versions.mix(SLOW_ANNOTATION.out.versions)
             }
 
             assemblies_plus_faa_and_gff = assemblies.join(
@@ -654,13 +617,6 @@ workflow METTANNOTATOR {
                 rfam_ncrna_models
             )
             ch_versions = ch_versions.mix(DETECT_NCRNA.out.versions.first())
-
-            if ( !params.fast ) {
-                SANNTIS(
-                    INTERPROSCAN.out.ips_annotations.join(annotations_gbk)
-                )
-                ch_versions = ch_versions.mix(SANNTIS.out.versions.first())
-            }
 
             GECCO_RUN(
                 annotations_gbk.map { meta, gbk -> [meta, gbk, []] }, []
@@ -717,15 +673,15 @@ workflow METTANNOTATOR {
 
             if ( !params.fast ) {
                 annotate_gff_input = annotate_gff_input.join(
-                    INTERPROSCAN.out.ips_annotations
+                    SLOW_ANNOTATION.out.ips_annotations
                 ).join(
-                    SANNTIS.out.sanntis_gff, remainder: true
+                    SLOW_ANNOTATION.out.sanntis_gff, remainder: true
                 ).join(
-                    UNIFIRE.out.arba, remainder: true
+                    SLOW_ANNOTATION.out.arba, remainder: true
                 ).join(
-                    UNIFIRE.out.unirule, remainder: true
+                    SLOW_ANNOTATION.out.unirule, remainder: true
                 ).join(
-                    UNIFIRE.out.pirsr, remainder: true
+                    SLOW_ANNOTATION.out.pirsr, remainder: true
                 )
             } else {
                 annotate_gff_input = annotate_gff_input.map { it ->

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -11,50 +11,22 @@ include { paramsSummaryLog; paramsSummaryMap; fromSamplesheet } from 'plugin/nf-
     IMPORT LOCAL MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { AMRFINDER_PLUS_GET_SPECIES_NAME            } from '../modules/local/amrfinder_plus'
-include { AMRFINDER_PLUS; AMRFINDER_PLUS_TO_GFF      } from '../modules/local/amrfinder_plus'
-include { AMRFINDER_PLUS_TSV_POSTPROCESSING          } from '../modules/local/amrfinder_plus'
-include { DEFENSE_FINDER                             } from '../modules/local/defense_finder'
-include { CRISPRCAS_FINDER                           } from '../modules/local/crisprcasfinder'
-include { EGGNOG_MAPPER as EGGNOG_MAPPER_ORTHOLOGS   } from '../modules/local/eggnog'
-include { EGGNOG_MAPPER as EGGNOG_MAPPER_ANNOTATIONS } from '../modules/local/eggnog'
-include { DETECT_TRNA                                } from '../modules/local/detect_trna'
-include { DETECT_NCRNA                               } from '../modules/local/detect_ncrna'
 include { ANNOTATE_GFF                               } from '../modules/local/annotate_gff'
-include { ANTISMASH                                  } from '../modules/local/antismash'
-include { ANTISMASH_TO_GFF                           } from '../modules/local/antismash'
-include { ANTISMASH_SUMMARY                          } from '../modules/local/antismash'
-include { DBCAN                                      } from '../modules/local/dbcan'
 include { CIRCOS_PLOT                                } from '../modules/local/circos_plot'
-include { PSEUDOFINDER                               } from '../modules/local/pseudofinder'
-include { PSEUDOFINDER_POSTPROCESSING                } from '../modules/local/pseudofinder'
 include { STAGE_FAST_OUTPUTS                         } from '../modules/local/stage_fast_outputs'
 
 include { DOWNLOAD_DATABASES                         } from '../subworkflows/download_databases'
 include { SLOW_ANNOTATION                            } from '../subworkflows/slow_annotation'
 include { GENE_CALLING                               } from '../subworkflows/gene_calling'
+include { FAST_ANNOTATION                            } from '../subworkflows/fast_annotation'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT NF-CORE MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { BAKTA_BAKTA                 } from '../modules/nf-core/bakta/bakta/main'
-include { GECCO_RUN                   } from '../modules/nf-core/gecco/run/main'
-include { QUAST                       } from '../modules/nf-core/quast/main'
 include { MULTIQC                     } from '../modules/nf-core/multiqc/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/custom/dumpsoftwareversions/main'
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT NF-CORE MODULES/SUBWORKFLOWS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-//
-// MODULE: Installed directly from nf-core/modules
-//
-
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -334,154 +306,53 @@ workflow METTANNOTATOR {
 
         if ( !params.gene_calling_only ) {
 
-            assemblies_for_quast = assemblies.join(
-                annotations_gff
-            ).map { it -> tuple(it[0], it[1], it[2]) }
-
-            QUAST(
-                assemblies_for_quast.map { tuple(it[0], it[1]) }, // the assembly
-                assemblies_for_quast.map { tuple(it[0], it[2]) }, // the GFF
-            )
-            ch_versions = ch_versions.mix(QUAST.out.versions.first())
-
-            PSEUDOFINDER(
+            FAST_ANNOTATION(
+                annotations_faa,
+                annotations_gff,
+                annotations_gbk,
+                annotations_fna,
                 compliant_gbk,
+                compliant_gff,
+                assemblies,
+                GENE_CALLING.out.detected_kingdom,
+                amrfinder_plus_db,
+                antismash_db,
+                defense_finder_db,
+                dbcan_db,
+                eggnog_db,
+                rfam_ncrna_models,
                 pseudofinder_db
             )
-            ch_versions = ch_versions.mix(PSEUDOFINDER.out.versions.first())
-
-            PSEUDOFINDER_POSTPROCESSING(
-                annotations_gff.join(
-                    compliant_gff
-                ).join(
-                    PSEUDOFINDER.out.pseudofinder_gff
-                )
-            )
-            ch_versions = ch_versions.mix(PSEUDOFINDER_POSTPROCESSING.out.versions.first())
-
-            CRISPRCAS_FINDER( assemblies )
-            ch_versions = ch_versions.mix(CRISPRCAS_FINDER.out.versions.first())
-
-            // EGGNOG_MAPPER_ORTHOLOGS - needs a third empty file in mode=mapper
-            proteins_for_emapper_orth = annotations_faa.map { it -> tuple( it[0], file(it[1]), file("NO_FILE") ) }
-
-            EGGNOG_MAPPER_ORTHOLOGS(
-                proteins_for_emapper_orth,
-                Channel.value("mapper"),
-                eggnog_db
-            )
-            ch_versions = ch_versions.mix(EGGNOG_MAPPER_ORTHOLOGS.out.versions.first())
-
-            // EGGNOG_MAPPER_ANNOTATIONS - needs a second empty file in mode=annotations
-            orthologs_for_annotations = assemblies.join(EGGNOG_MAPPER_ORTHOLOGS.out.orthologs, by: 0).map {
-                it -> {
-                    tuple(it[0], file("NO_FILE"), file(it[2])) // tuple( meta , <empty> , assembly )
-                }
-            }
-
-            EGGNOG_MAPPER_ANNOTATIONS(
-                orthologs_for_annotations,
-                Channel.value("annotations"),
-                eggnog_db
-            )
-            ch_versions = ch_versions.mix(EGGNOG_MAPPER_ANNOTATIONS.out.versions.first())
+            ch_versions = ch_versions.mix(FAST_ANNOTATION.out.versions)
 
             if ( !params.fast ) {
                 SLOW_ANNOTATION(annotations_faa, annotations_gbk, interproscan_db)
                 ch_versions = ch_versions.mix(SLOW_ANNOTATION.out.versions)
             }
 
-            assemblies_plus_faa_and_gff = assemblies.join(
-                annotations_faa
-            ).join(
-                annotations_gff
-            )
-
-            AMRFINDER_PLUS_GET_SPECIES_NAME(
-                assemblies,
-                amrfinder_plus_db
-            )
-
-            AMRFINDER_PLUS(
-                assemblies_plus_faa_and_gff.join(AMRFINDER_PLUS_GET_SPECIES_NAME.out.detected_organism),
-                amrfinder_plus_db
-            )
-            ch_versions = ch_versions.mix(AMRFINDER_PLUS.out.versions.first())
-
-            AMRFINDER_PLUS_TSV_POSTPROCESSING(AMRFINDER_PLUS.out.amrfinder_tsv)
-            ch_versions = ch_versions.mix(AMRFINDER_PLUS_TSV_POSTPROCESSING.out.versions.first())
-
-            AMRFINDER_PLUS_TO_GFF( AMRFINDER_PLUS_TSV_POSTPROCESSING.out.amrfinder_tsv )
-            ch_versions = ch_versions.mix(AMRFINDER_PLUS_TO_GFF.out.versions.first())
-
-            DEFENSE_FINDER(
-                annotations_faa.join( annotations_gff ),
-                defense_finder_db
-            )
-            ch_versions = ch_versions.mix(DEFENSE_FINDER.out.versions.first())
-
-            DETECT_TRNA(
-                annotations_fna.join( GENE_CALLING.out.detected_kingdom )
-            )
-            ch_versions = ch_versions.mix(DETECT_TRNA.out.versions.first())
-
-            DETECT_NCRNA(
-                annotations_fna,
-                rfam_ncrna_models
-            )
-            ch_versions = ch_versions.mix(DETECT_NCRNA.out.versions.first())
-
-            GECCO_RUN(
-                annotations_gbk.map { meta, gbk -> [meta, gbk, []] }, []
-            )
-            ch_versions = ch_versions.mix(GECCO_RUN.out.versions.first())
-
-            ANTISMASH(
-                annotations_gbk,
-                antismash_db
-            )
-            ch_versions = ch_versions.mix(ANTISMASH.out.versions.first())
-
-            ANTISMASH_TO_GFF(
-                ANTISMASH.out.json
-            )
-
-            ch_versions = ch_versions.mix(ANTISMASH_TO_GFF.out.versions.first())
-
-            ANTISMASH_SUMMARY(
-                ANTISMASH_TO_GFF.out.gff
-            )
-            ch_versions = ch_versions.mix(ANTISMASH_SUMMARY.out.versions.first())
-
-            DBCAN(
-                annotations_faa.join( annotations_gff ),
-                dbcan_db
-            )
-            ch_versions = ch_versions.mix(DBCAN.out.versions.first())
-
             /**********************************************/
             /* Combine the results into a single GFF file */
             /**********************************************/
             annotate_gff_input = annotations_gff.join(
-                EGGNOG_MAPPER_ANNOTATIONS.out.annotations
+                FAST_ANNOTATION.out.eggnog_annotations
             ).join(
-                DETECT_NCRNA.out.ncrna_tblout
+                FAST_ANNOTATION.out.ncrna_tblout
             ).join(
-                DETECT_TRNA.out.trna_gff
+                FAST_ANNOTATION.out.trna_gff
             ).join(
-                CRISPRCAS_FINDER.out.hq_gff, remainder: true
+                FAST_ANNOTATION.out.crisprcas_hq_gff, remainder: true
             ).join(
-                AMRFINDER_PLUS.out.amrfinder_tsv, remainder: true
+                FAST_ANNOTATION.out.amrfinder_tsv, remainder: true
             ).join(
-                ANTISMASH_TO_GFF.out.gff, remainder: true
+                FAST_ANNOTATION.out.antismash_gff, remainder: true
             ).join(
-                GECCO_RUN.out.gff, remainder: true
+                FAST_ANNOTATION.out.gecco_gff, remainder: true
             ).join(
-                DBCAN.out.dbcan_gff, remainder: true
+                FAST_ANNOTATION.out.dbcan_gff, remainder: true
             ).join(
-                DEFENSE_FINDER.out.gff, remainder: true
+                FAST_ANNOTATION.out.defense_gff, remainder: true
             ).join(
-                PSEUDOFINDER_POSTPROCESSING.out.pseudofinder_processed_gff, remainder: true
+                FAST_ANNOTATION.out.pseudofinder_gff, remainder: true
             )
 
             if ( !params.fast ) {
@@ -535,7 +406,7 @@ workflow METTANNOTATOR {
             ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
             ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
             ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-            ch_multiqc_files = ch_multiqc_files.mix( QUAST.out.results.collect { it[1] }.ifEmpty([]) )
+            ch_multiqc_files = ch_multiqc_files.mix( FAST_ANNOTATION.out.quast_results.collect { it[1] }.ifEmpty([]) )
 
 
             MULTIQC(

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -11,11 +11,6 @@ include { paramsSummaryLog; paramsSummaryMap; fromSamplesheet } from 'plugin/nf-
     IMPORT LOCAL MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { LOOKUP_KINGDOM                             } from '../modules/local/lookup_kingdom'
-include { PROKKA as PROKKA_STANDARD                  } from '../modules/local/prokka'
-include { PROKKA as PROKKA_COMPLIANT                 } from '../modules/local/prokka'
-include { RENAME_CONTIGS as SHORTEN_CONTIG_NAMES     } from '../modules/local/rename_contigs'
-include { RENAME_CONTIGS as REVERT_CONTIG_RENAMING   } from '../modules/local/rename_contigs'
 include { AMRFINDER_PLUS_GET_SPECIES_NAME            } from '../modules/local/amrfinder_plus'
 include { AMRFINDER_PLUS; AMRFINDER_PLUS_TO_GFF      } from '../modules/local/amrfinder_plus'
 include { AMRFINDER_PLUS_TSV_POSTPROCESSING          } from '../modules/local/amrfinder_plus'
@@ -34,12 +29,10 @@ include { CIRCOS_PLOT                                } from '../modules/local/ci
 include { PSEUDOFINDER                               } from '../modules/local/pseudofinder'
 include { PSEUDOFINDER_POSTPROCESSING                } from '../modules/local/pseudofinder'
 include { STAGE_FAST_OUTPUTS                         } from '../modules/local/stage_fast_outputs'
-include { NORMALIZE_ENSEMBL_GFF                      } from '../modules/local/normalize_ensembl_gff'
-include { GFF_TO_GBK                                 } from '../modules/local/gff_to_gbk'
-
 
 include { DOWNLOAD_DATABASES                         } from '../subworkflows/download_databases'
 include { SLOW_ANNOTATION                            } from '../subworkflows/slow_annotation'
+include { GENE_CALLING                               } from '../subworkflows/gene_calling'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -100,6 +93,7 @@ workflow METTANNOTATOR {
 
     pseudofinder_db = channel.empty()
 
+    bakta_db = channel.empty()
 
     // Info required for completion email and summary
     def multiqc_report = []
@@ -326,198 +320,17 @@ workflow METTANNOTATOR {
     } else {
 
         assemblies_raw = Channel.fromSamplesheet("input")
-        // [meta, assembly] for all samples — feeds LOOKUP_KINGDOM and all assembly-level tools
         assemblies = assemblies_raw.map { row -> [row[0], row[1]] }
-        annotations_fna = channel.empty()
-        annotations_gbk = channel.empty()
-        annotations_faa = channel.empty()
-        annotations_gff = channel.empty()
-        compliant_gbk = channel.empty()
-        compliant_gff = channel.empty()
 
-        // Per-sample external gene calls: rows where annotation_source is prokka/bakta/ensembl.
-        // When the gene_calls_gff column is absent (standard samplesheet), this channel is empty.
-        // Tuple: [meta, assembly, gene_calls_gff, gene_calls_faa, gene_calls_gbk]
-        ext_gene_call_rows = assemblies_raw
-            .filter { it[0].annotation_source in ['prokka', 'bakta', 'ensembl'] }
-            .map { [it[0], it[1], it[2], it[3], it[4]] }
+        GENE_CALLING(assemblies_raw, assemblies, bakta_db)
+        ch_versions = ch_versions.mix(GENE_CALLING.out.versions)
 
-        ext_gene_call_rows.branch {
-            ensembl: it[0].annotation_source == 'ensembl'
-            direct:  true   // prokka or bakta — GFF used as-is
-        }.set { ext_gc_branches }
-
-        NORMALIZE_ENSEMBL_GFF(
-            ext_gc_branches.ensembl.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
-        )
-        ch_versions = ch_versions.mix(NORMALIZE_ENSEMBL_GFF.out.versions)
-
-        // Ensembl samples with a user-supplied GBK skip GFF_TO_GBK.
-        ext_gc_branches.ensembl.branch {
-            has_gbk:   it[4]
-            needs_gbk: true
-        }.set { ensembl_gbk_branches }
-
-        GFF_TO_GBK(
-            NORMALIZE_ENSEMBL_GFF.out.normalised_gff
-                .join( ensembl_gbk_branches.needs_gbk.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
-                .join( ensembl_gbk_branches.needs_gbk.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
-        )
-        ch_versions = ch_versions.mix(GFF_TO_GBK.out.versions)
-
-        ext_annotations_gff = NORMALIZE_ENSEMBL_GFF.out.normalised_gff
-            .mix( ext_gc_branches.direct.map { meta, _assembly, gff, _faa, _gbk -> [meta, gff] } )
-        ext_annotations_faa = ext_gc_branches.ensembl.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] }
-            .mix( ext_gc_branches.direct.map { meta, _assembly, _gff, faa, _gbk -> [meta, faa] } )
-        ext_annotations_fna = ext_gc_branches.ensembl.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] }
-            .mix( ext_gc_branches.direct.map { meta, assembly, _gff, _faa, _gbk -> [meta, assembly] } )
-
-        // Any external sample (ensembl or direct) that provides a GBK uses it directly,
-        // bypassing GFF_TO_GBK. compliant_gff for direct samples uses their GFF as-is
-        // (no contig renaming). Ensembl compliant_gff comes from NORMALIZE_ENSEMBL_GFF.
-        ext_gbk = ensembl_gbk_branches.has_gbk
-            .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] }
-            .mix( ext_gc_branches.direct
-                .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
-                .map    { meta, _assembly, _gff, _faa, gbk -> [meta, gbk] } )
-        ext_direct_compliant_gff = ext_gc_branches.direct
-            .filter { meta, _assembly, _gff, _faa, gbk -> gbk }
-            .map    { meta, _assembly, gff, _faa, _gbk -> [meta, gff] }
-
-        LOOKUP_KINGDOM( assemblies )
-        ch_versions = ch_versions.mix(LOOKUP_KINGDOM.out.versions.first())
-
-        assemblies_with_kingdom = assemblies.join( LOOKUP_KINGDOM.out.detected_kingdom )
-
-        if ( params.gene_calls ) {
-
-            def gene_calls_dir = file(params.gene_calls)
-
-            def load_files = { pattern, strip_suffix ->
-                channel
-                    .fromPath(pattern, checkIfExists: false)
-                    .map { f ->
-                        def name = f.name.replaceAll(strip_suffix + '$', '')
-                        tuple(name, f)
-                    }
-            }
-
-            // Preserve the original samplesheet meta (needed for downstream joins, e.g. LOOKUP_KINGDOM)
-            assemblies_by_prefix = assemblies.map { meta, assembly -> [meta.prefix, meta] }
-
-            // Load annotation files from the appropriate tool's output directory.
-            // When --bakta is set, load from functional_annotation/bakta/ (bakta compliant = standard bakta outputs).
-            // Otherwise load from functional_annotation/prokka/ and functional_annotation/prokka_compliant/.
-            // Prokka: .faa / .gbk / .gff / .fna   Bakta: .faa / .gbff / .gff3 / .fna
-            if ( params.bakta ) {
-                gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.faa",   '\\.faa')
-                gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
-                gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
-                gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.fna",   '\\.fna')
-                gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gbff",  '\\.gbff')
-                gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/bakta/*.gff3",  '\\.gff3')
-            } else {
-                gc_faa           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.faa",            '\\.faa')
-                gc_gbk           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gbk",            '\\.gbk')
-                gc_gff           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.gff",            '\\.gff')
-                gc_fna           = load_files("${gene_calls_dir}/**/functional_annotation/prokka/*.fna",            '\\.fna')
-                gc_compliant_gbk = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gbk", '\\.gbk')
-                gc_compliant_gff = load_files("${gene_calls_dir}/**/functional_annotation/prokka_compliant/*.gff", '\\.gff')
-            }
-
-            annotations_faa  = assemblies_by_prefix.join(gc_faa).map           { prefix, meta, f -> tuple(meta, f) }
-            annotations_gbk  = assemblies_by_prefix.join(gc_gbk).map           { prefix, meta, f -> tuple(meta, f) }
-            annotations_gff  = assemblies_by_prefix.join(gc_gff).map           { prefix, meta, f -> tuple(meta, f) }
-            annotations_fna  = assemblies_by_prefix.join(gc_fna).map           { prefix, meta, f -> tuple(meta, f) }
-            compliant_gbk    = assemblies_by_prefix.join(gc_compliant_gbk).map { prefix, meta, f -> tuple(meta, f) }
-            compliant_gff    = assemblies_by_prefix.join(gc_compliant_gff).map { prefix, meta, f -> tuple(meta, f) }
-
-        } else {
-
-            // Exclude samples that supply per-sample external gene calls from Prokka/Bakta
-            assemblies_for_gene_calling = assemblies_with_kingdom.filter { meta, _assembly, _kingdom ->
-                !(meta.annotation_source in ['prokka', 'bakta', 'ensembl'])
-            }
-
-            if ( params.bakta ) {
-
-                assemblies_for_gene_calling.branch {
-                    bacteria: it[2] == "Bacteria"
-                    archaea: it[2] == "Archaea"
-                }.set { assemblies_to_annotate }
-
-                BAKTA_BAKTA( assemblies_to_annotate.bacteria, bakta_db )
-                ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions.first())
-
-                prokka_input = assemblies_to_annotate.archaea
-
-            } else {
-
-                prokka_input = assemblies_for_gene_calling
-
-            }
-
-            // Prokka crashes with long contig names, so we temporary rename contigs before running it
-            SHORTEN_CONTIG_NAMES(
-                prokka_input.map { meta, fasta, _kingdom -> [ meta, fasta ] },
-                []
-            )
-            ch_versions = ch_versions.mix(SHORTEN_CONTIG_NAMES.out.versions.first())
-
-            renamed_prokka_input = SHORTEN_CONTIG_NAMES.out.modified_fasta
-                .join( prokka_input )
-                .map { meta, renamed_fasta, _original_fasta, kingdom ->
-                    [ meta, renamed_fasta, kingdom ]
-                }
-            PROKKA_STANDARD( renamed_prokka_input, Channel.value("standard") )
-            PROKKA_COMPLIANT( renamed_prokka_input, Channel.value("compliant") )
-            ch_versions = ch_versions.mix(PROKKA_STANDARD.out.versions.first())
-
-            // Revert contig renaming in both GBK and GFF files, so they match the original FASTA
-            PROKKA_STANDARD.out.gbk
-                .mix(PROKKA_STANDARD.out.gff)
-                .mix(PROKKA_STANDARD.out.fna)
-                .groupTuple()
-                .join(SHORTEN_CONTIG_NAMES.out.fasta_ids_mapping)
-                .multiMap { meta, files_list, names_mapping ->
-                    files: [ meta, files_list ]
-                    mapping: names_mapping
-            }.set { revert_contig_renaming_input }
-            REVERT_CONTIG_RENAMING(
-                revert_contig_renaming_input.files,
-                revert_contig_renaming_input.mapping
-            )
-
-            if ( params.bakta ) {
-
-                annotations_gbk = annotations_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( REVERT_CONTIG_RENAMING.out.modified_gbk )
-                annotations_gff = annotations_gff.mix( BAKTA_BAKTA.out.gff ).mix( REVERT_CONTIG_RENAMING.out.modified_gff )
-                annotations_fna = annotations_fna.mix( BAKTA_BAKTA.out.fna ).mix( REVERT_CONTIG_RENAMING.out.modified_fasta )
-                annotations_faa = annotations_faa.mix( BAKTA_BAKTA.out.faa ).mix( PROKKA_STANDARD.out.faa )
-                compliant_gbk = compliant_gbk.mix( BAKTA_BAKTA.out.gbk ).mix( PROKKA_COMPLIANT.out.gbk )
-                compliant_gff = compliant_gff.mix( BAKTA_BAKTA.out.gff ).mix( PROKKA_COMPLIANT.out.gff )
-
-            } else {
-
-                annotations_gbk = REVERT_CONTIG_RENAMING.out.modified_gbk
-                annotations_gff = REVERT_CONTIG_RENAMING.out.modified_gff
-                annotations_fna = REVERT_CONTIG_RENAMING.out.modified_fasta
-                annotations_faa = PROKKA_STANDARD.out.faa
-
-                compliant_gbk = PROKKA_COMPLIANT.out.gbk
-                compliant_gff = PROKKA_COMPLIANT.out.gff
-            }
-        }
-
-        // Mix per-sample external gene calls (samplesheet gene_calls_gff column) into the main
-        // annotation channels. Empty no-op when no external gene calls are provided.
-        annotations_gff = annotations_gff.mix(ext_annotations_gff)
-        annotations_faa = annotations_faa.mix(ext_annotations_faa)
-        annotations_fna = annotations_fna.mix(ext_annotations_fna)
-        annotations_gbk = annotations_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
-        compliant_gbk   = compliant_gbk.mix(GFF_TO_GBK.out.gbk).mix(ext_gbk)
-        compliant_gff   = compliant_gff.mix(NORMALIZE_ENSEMBL_GFF.out.normalised_gff).mix(ext_direct_compliant_gff)
-
+        annotations_faa  = GENE_CALLING.out.annotations_faa
+        annotations_gff  = GENE_CALLING.out.annotations_gff
+        annotations_gbk  = GENE_CALLING.out.annotations_gbk
+        annotations_fna  = GENE_CALLING.out.annotations_fna
+        compliant_gbk    = GENE_CALLING.out.compliant_gbk
+        compliant_gff    = GENE_CALLING.out.compliant_gff
 
         if ( !params.gene_calling_only ) {
 
@@ -608,7 +421,7 @@ workflow METTANNOTATOR {
             ch_versions = ch_versions.mix(DEFENSE_FINDER.out.versions.first())
 
             DETECT_TRNA(
-                annotations_fna.join( LOOKUP_KINGDOM.out.detected_kingdom )
+                annotations_fna.join( GENE_CALLING.out.detected_kingdom )
             )
             ch_versions = ch_versions.mix(DETECT_TRNA.out.versions.first())
 

--- a/workflows/mettannotator.nf
+++ b/workflows/mettannotator.nf
@@ -386,7 +386,7 @@ workflow METTANNOTATOR {
             )
             ch_versions = ch_versions.mix(CIRCOS_PLOT.out.versions.first())
 
-        } 
+        }
 
         CUSTOM_DUMPSOFTWAREVERSIONS(
             ch_versions.unique().collectFile(name: 'collated_versions.yml')


### PR DESCRIPTION
## Subworkflow refactor (`feature/subworkflow-refactor`)

Refactored `workflows/mettannotator.nf` into three independent, reusable subworkflows. No pipeline behaviour is changed.

### New subworkflows

| Subworkflow | Modules |
|---|---|
| `subworkflows/gene_calling.nf` | LOOKUP_KINGDOM, PROKKA (standard + compliant), RENAME_CONTIGS, BAKTA_BAKTA, NORMALIZE_ENSEMBL_GFF, GFF_TO_GBK |
| `subworkflows/fast_annotation.nf` | QUAST, PSEUDOFINDER, PSEUDOFINDER_POSTPROCESSING, CRISPRCAS_FINDER, EGGNOG_MAPPER_ORTHOLOGS, EGGNOG_MAPPER_ANNOTATIONS, AMRFINDER_PLUS_GET_SPECIES_NAME, AMRFINDER_PLUS, AMRFINDER_PLUS_TSV_POSTPROCESSING, AMRFINDER_PLUS_TO_GFF, DEFENSE_FINDER, DETECT_TRNA, DETECT_NCRNA, GECCO_RUN, ANTISMASH, ANTISMASH_TO_GFF, ANTISMASH_SUMMARY, DBCAN |
| `subworkflows/slow_annotation.nf` | ADD_TAXID_TO_PROTEIN_FASTA, INTERPROSCAN, UNIFIRE, SANNTIS |


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/mettannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [] `README.md` is updated (including new tool citations and authors/contributors).
