### PR TITLE
Fix dbCAN download, defense-finder HOME, pseudofinder diamond index, rfam path, and interproscan container tag

### DIFF
--- a/modules/local/dbcan.nf
+++ b/modules/local/dbcan.nf
@@ -3,7 +3,7 @@ process DBCAN {
     tag "${meta.prefix}"
 
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] ?
-        'https://depot.galaxyproject.org/singularity/dbcan-5.1.2--pyhdfd78af_0' :
+        'https://depot.galaxyproject.org/singularity/dbcan%3A5.1.2--pyhdfd78af_0' :
         'biocontainers/dbcan-5.1.2--pyhdfd78af_0' }"
 
     input:

--- a/modules/local/dbcan_getdb.nf
+++ b/modules/local/dbcan_getdb.nf
@@ -14,12 +14,31 @@ process DBCAN_GETDB {
 
     script:
     """
-    wget -r -np -nH --cut-dirs=3 --reject "index.html*" https://bcb.unl.edu/dbCAN2/download/run_dbCAN_database_total/db_v5-2_9-13-2025/
+    mkdir -p dbcan
 
-    mv db_v5-2_9-13-2025 dbcan/
+    # CAZyme databases
+    wget -O dbcan/CAZy.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/CAZy.dmnd"
+    wget -O dbcan/dbCAN.hmm "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/dbCAN.hmm"
+    wget -O dbcan/dbCAN-sub.hmm "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/dbCAN_sub.hmm"
+    wget -O dbcan/fam-substrate-mapping.tsv "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/fam-substrate-mapping.tsv"
 
-    # there is a mismatch between the expected name of the sub db and the way it is named in the database
-    # the code below is a temporary fix for this until it is properly addressed by the tool developers
+    # CGC-related databases
+    wget -O dbcan/TCDB.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/TCDB.dmnd"
+    wget -O dbcan/TF.hmm "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/TF.hmm"
+    wget -O dbcan/TF.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/TF.dmnd"
+    wget -O dbcan/STP.hmm "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/STP.hmm"
+    wget -O dbcan/PUL.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/PUL.dmnd"
+    wget -O dbcan/dbCAN-PUL.xlsx "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/dbCAN-PUL.xlsx"
+    wget -O dbcan/dbCAN-PUL.tar.gz "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/dbCAN-PUL.tar.gz"
+    wget -O dbcan/peptidase_db.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/peptidase_db.dmnd"
+    wget -O dbcan/sulfatlas_db.dmnd "https://pro.unl.edu/dbCAN2/download_file.php?file=run_dbCAN_database_total/db_v5-2_9-13-2025/sulfatlas_db.dmnd"
+
+    tar -C dbcan -xzf dbcan/dbCAN-PUL.tar.gz
+
+
+    # there is a mismatch between the expected name of the sub db and the way
+    # it is named in the database the code below is a temporary fix for this
+    # until it is properly addressed by the tool developers
     if [ -f "dbcan/dbCAN_sub.hmm" ]; then
         mv "dbcan/dbCAN_sub.hmm" "dbcan/dbCAN-sub.hmm"
     fi

--- a/modules/local/defense_finder.nf
+++ b/modules/local/defense_finder.nf
@@ -17,6 +17,10 @@ process DEFENSE_FINDER {
 
     script:
     """
+    # defense-finder writes ~/.defensefinder_model_lastversion to \$HOME on every run;
+    # the container's \$HOME may not exist/be writable, so point it at the task workdir.
+    export HOME=\$PWD
+
     defense-finder run \\
         -o defense_finder_output \\
         --antidefensefinder \\

--- a/modules/local/pseudofinder.nf
+++ b/modules/local/pseudofinder.nf
@@ -14,9 +14,17 @@ process PSEUDOFINDER {
 
     script:
     """
+    # pseudofinder --diamond requires a pre-built <fasta>.dmnd alongside the FASTA and does
+    # not build it itself; the staged DB ships only uniprot_sprot.fasta, so build the index
+    # here in the (writable) work dir using the same diamond that runs the search.
+    diamond makedb \
+    --in ${pseudofinder_db}/uniprot_sprot.fasta \
+    --db uniprot_sprot.fasta \
+    --threads ${task.cpus}
+
     pseudofinder.py annotate \
     -g ${compliant_gbk} \
-    -db ${pseudofinder_db}/uniprot_sprot.fasta.dmnd \
+    -db uniprot_sprot.fasta \
     -op ${meta.prefix} \
     -t ${task.cpus} \
     --diamond

--- a/modules/local/rfam_getmodels.nf
+++ b/modules/local/rfam_getmodels.nf
@@ -16,7 +16,7 @@ process RFAM_GETMODELS {
     """
     mkdir -p rfam_ncrna_cms/
 
-    wget --recursive --cut-dirs=5 -nH ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/genomes-pipeline/rfam_15.0/ncrna_cms/ -P rfam_ncrna_cms
+    wget --recursive --cut-dirs=6 -nH ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/genomes-pipeline/rfam_15.0/ncrna_cms/ -P rfam_ncrna_cms
 
     echo '15.0' > rfam_ncrna_cms/VERSION.txt
     """

--- a/subworkflows/download_databases.nf
+++ b/subworkflows/download_databases.nf
@@ -74,8 +74,8 @@ workflow DOWNLOAD_DATABASES {
             defense_finder_db = DEFENSE_FINDER_GETDB.out.defense_finder_db.first()
         }
 
-        if (dbcan_dir.exists()) {
-            log.info("DBCan database exists, or at least the expected folder.")
+        if (file("${dbcan_dir}/CAZy.dmnd").exists()) {
+            log.info("DBCan database exists (CAZy.dmnd found).")
             dbcan_db = tuple(
                 dbcan_dir,
                 file("${dbcan_dir}/VERSION.txt", checkIfExists: true).text // the DB version
@@ -118,11 +118,11 @@ workflow DOWNLOAD_DATABASES {
             eggnog_db = EGGNOG_MAPPER_GETDB.out.eggnog_db.first()
         }
 
-        if (!rfam_ncrna_models.exists()) {
+        if (!file("${rfam_ncrna_models}/Rfam.cm").exists()) {
             RFAM_GETMODELS()
             rfam_ncrna_models = RFAM_GETMODELS.out.rfam_ncrna_cms.first()
         } else {
-            log.info("RFam model files exists, or at least the expected folders.")
+            log.info("RFam model files exist (Rfam.cm found).")
             rfam_ncrna_models = tuple(
                 rfam_ncrna_models,
                 file("${rfam_ncrna_models}/VERSION.txt", checkIfExists: true).text

--- a/subworkflows/download_databases.nf
+++ b/subworkflows/download_databases.nf
@@ -89,7 +89,7 @@ workflow DOWNLOAD_DATABASES {
             log.info("InterproScan database exists, or at least the expected folder.")
             interproscan_db = tuple(
                 interproscan_dir,
-                file("${interproscan_dir}/VERSION.txt", checkIfExists: true).text // the DB version
+                file("${interproscan_dir}/VERSION.txt", checkIfExists: true).text.trim() // the DB version
             )
         } else {
             INTERPROSCAN_GETDB()


### PR DESCRIPTION
<!--
# ebi-metagenomics/mettannotator pull request

Many thanks for contributing to ebi-metagenomics/mettannotator!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/ebi-metagenomics/mettannotator/tree/master/.github/CONTRIBUTING.md)
-->

## Summary

- dbCAN download: Replaced the recursive wget of the dbCAN directory (which was failing due to the server returning HTML index pages) with explicit per-file downloads via the pro.unl.edu PHP endpoint. Also fixed the Singularity container URL — the colon in the tag must be percent-encoded (%3A) for the depot.galaxyproject.org URL scheme.
- defense-finder: Set HOME=$PWD before invoking defense-finder run to prevent it writing ~/.defensefinder_model_lastversion to a non-existent or read-only home directory inside the container.
- pseudofinder: Build the DIAMOND index (makedb) in the writable work directory at runtime, since the staged DB ships only the FASTA. This removes the dependency on a pre-built .dmnd file.
- Rfam download: Corrected --cut-dirs from 5 to 6 to match the actual FTP path depth, so files land directly in rfam_ncrna_cms/ rather than a nested subdirectory.
- InterProScan container tag: Strip the trailing newline from VERSION.txt (.text.trim()) so the version string is not embedded with a \n in the container image name, which was causing Nextflow to fail to match the cached image and crash during the pull.
- DB existence checks: Tightened dbcan and rfam pre-flight checks to verify a key file exists (CAZy.dmnd, Rfam.cm) rather than just the directory, preventing silent use of an incomplete database.

## Test plan

- [x] Run pipeline end-to-end with --dbs pointing at a pre-populated database directory and confirm all cached images are resolved without pulling (no NoSuchFileException for interproscan)
- [x] Run with --dbs pointing at an empty/missing dbCAN directory and confirm individual files are downloaded correctly and CAZy.dmnd is present
- [x] Confirm defense-finder produces output without a ~/.defensefinder_model_lastversion error
- [x] Confirm pseudofinder runs without a missing .dmnd error
- [x] Confirm Rfam models download into the expected flat directory structure

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/mettannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
